### PR TITLE
Lower minimum Python to 3.10, fix ruff config for CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,8 +51,8 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.21
         env:
-          # Build for Python 3.12 and 3.13
-          CIBW_BUILD: "cp312-* cp313-*"
+          # Build for Python 3.10 - 3.13
+          CIBW_BUILD: "cp310-* cp311-* cp312-* cp313-*"
 
           # Skip 32-bit and musl (Alpine) builds
           CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux*"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.12"]
+        python-version: ["3.10", "3.12"]
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.12"]
+        python-version: ["3.10", "3.12"]
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Tests](https://github.com/afloresep/TMAP/actions/workflows/tests.yml/badge.svg)](https://github.com/afloresep/TMAP/actions/workflows/tests.yml)
 [![PyPI](https://img.shields.io/pypi/v/tmap2)](https://pypi.org/project/tmap2/)
-[![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org/downloads/)
+[![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 
 # TMAP2
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.1.0"
 description = "Tree-based visualization for high-dimensional data"
 readme = "README.md"
 license = {text = "MIT"}
-requires-python = ">=3.12"
+requires-python = ">=3.10"
 authors = [
     { name = "Alejandro Flores", email = "afloresep01@gmail.com" }
 ]
@@ -20,6 +20,8 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering :: Visualization",
@@ -34,6 +36,7 @@ dependencies = [
     "matplotlib>=3.7",
     "pandas>=2.2",
     "usearch>=2.16,<3",
+    "typing_extensions>=4.0; python_version < '3.11'",
 ]
 
 [project.optional-dependencies]
@@ -72,7 +75,7 @@ sdist.exclude = [
 
 [tool.ruff]
 line-length = 100
-target-version = "py312"
+target-version = "py310"
 exclude = ["extern/", "*.ipynb"]
 
 [tool.ruff.lint]

--- a/src/tmap/estimator.py
+++ b/src/tmap/estimator.py
@@ -2,9 +2,15 @@ from __future__ import annotations
 
 import math
 import pickle
+import sys
 import warnings
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Self
+from typing import TYPE_CHECKING, Any
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 import numpy as np
 from numpy.typing import NDArray


### PR DESCRIPTION
- requires-python >= 3.10 (was 3.12)
- Conditional typing_extensions dep for Self on <3.11
- Build wheels for cp310-cp313 in publish workflow
- Test matrix includes 3.10 and 3.12
- Consolidate ruff config into pyproject.toml (ruff.toml is gitignored)
- Fix all ruff errors: import sorting, long lines, UP035, N814