### PR TITLE
Rewrite examples to use current API, add README

### DIFF
--- a/docs/molecule_tutorial.md
+++ b/docs/molecule_tutorial.md
@@ -120,7 +120,7 @@ This is useful when you want to keep the fitted tree and coordinates for later a
 If you want the same workflow as a script, run:
 
 ```bash
-python examples/cluster_65053_tmap.py --nrows 3000 --output examples/cluster_65053.html
+python examples/molecules_tmap.py --nrows 3000 --output examples/cluster_65053.html
 ```
 
 Add `--serve` if you want it to start a local viewer.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,40 @@
+# Examples
+
+## Chemistry
+
+| Example | Description | Key features |
+|---------|-------------|--------------|
+| [`molecules_tmap.py`](molecules_tmap.py) | High-level molecular TMAP from a SMILES CSV | `TMAP(metric="jaccard")`, `fingerprints_from_smiles`, `molecular_properties`, `murcko_scaffolds` |
+| [`smiles_tmap.py`](smiles_tmap.py) | Low-level pipeline: MinHash → LSHForest → OGDF layout → TmapViz | `MinHash`, `LSHForest`, `layout_from_lsh_forest`, `LayoutConfig` |
+| [`sar_egfr.py`](sar_egfr.py) | SAR navigation for EGFR kinase inhibitors (ChEMBL data) | Activity cliffs, scaffold analysis, SAR paths, `boundary_edges`, `subtree_purity` |
+
+## Image datasets
+
+| Example | Description | Key features |
+|---------|-------------|--------------|
+| [`mnist_cosine_tmap.py`](mnist_cosine_tmap.py) | MNIST 70k digits with cosine metric | `TMAP(metric="cosine")`, `LayoutConfig`, `model.path()` |
+| [`pet_breed_audit.py`](pet_breed_audit.py) | Oxford-IIIT Pets classifier audit with ResNet-50 embeddings | `TMAP(metric="cosine")`, graph analysis, image tooltips, failure path tracing |
+
+## Proteins
+
+| Example | Description | Key features |
+|---------|-------------|--------------|
+| [`afdb_clusters_tmap.py`](afdb_clusters_tmap.py) | AlphaFold DB: 2.3M structural clusters from Foldseek | Precomputed `KNNGraph`, taxonomy resolution, `node_diversity`, large-scale pipeline |
+
+## Quick start
+
+The fastest way to try TMAP:
+
+```python
+from tmap import TMAP, fingerprints_from_smiles
+
+fps = fingerprints_from_smiles(["CCO", "c1ccccc1", "CC(=O)O", ...])
+model = TMAP(metric="jaccard").fit(fps)
+model.to_html("output.html")
+```
+
+## Data files
+
+- `cluster_65053.csv` — ~6k SMILES from an Enamine chemical cluster (used by `molecules_tmap.py` and `smiles_tmap.py`)
+- `afdb_cluster_data/` — downloaded automatically by `afdb_clusters_tmap.py`
+- `data/` — cached embeddings and datasets (created by examples on first run)

--- a/examples/mnist_cosine_tmap.py
+++ b/examples/mnist_cosine_tmap.py
@@ -1,6 +1,6 @@
 """MNIST digits → TMAP with cosine metric.
 
-Demonstrates the new cosine/euclidean metric support on a classic dataset.
+Demonstrates cosine metric support on a classic dataset.
 70,000 handwritten digits (784D pixel vectors) embedded as an explorable tree.
 
 Usage:
@@ -20,19 +20,16 @@ from sklearn.datasets import fetch_openml
 from tmap import TMAP
 from tmap.layout import LayoutConfig, ScalingType
 
+
 def main() -> None:
-    # ------------------------------------------------------------------
     # 1. Load MNIST (70k samples, 784D)
-    # ------------------------------------------------------------------
     print("Loading MNIST...")
     mnist = fetch_openml("mnist_784", version=1, as_frame=False, parser="auto")
     X = mnist.data.astype(np.float32)
     labels = mnist.target.astype(int)
     print(f"  Shape: {X.shape}, labels: {np.unique(labels)}")
 
-    # ------------------------------------------------------------------
     # 2. Fit TMAP with cosine metric
-    # ------------------------------------------------------------------
     cfg = LayoutConfig()
     cfg.k = 20
     cfg.kc = 200
@@ -42,8 +39,8 @@ def main() -> None:
     cfg.sl_scaling_type = ScalingType.RelativeToDrawing
     cfg.fme_iterations = 1000
     cfg.deterministic = True
-    cfg.seed = 42 
-    
+    cfg.seed = 42
+
     print("\nFitting TMAP (metric='cosine', n_neighbors=20)...")
     t0 = time.perf_counter()
     model = TMAP(
@@ -63,7 +60,7 @@ def main() -> None:
     # ------------------------------------------------------------------
     viz = model.to_tmapviz()
     viz.background_color = "#FFFFFF"
-    
+
     viz.add_color_layout("digit", labels.tolist(), categorical=True, color="tab10")
     out_path = viz.write_html("examples/mnist_tmap.html")
     print(f"\n  Saved: {out_path}")
@@ -71,44 +68,15 @@ def main() -> None:
     # ------------------------------------------------------------------
     # 4. Trace paths between morphologically similar digits
     # ------------------------------------------------------------------
-    # These pairs are interesting because the digits are visually similar
-    # and the tree path reveals the gradual transition between them.
-#     pairs = [(3, 8), (4, 9), (7, 1), (5, 6)]
-
-#     tree = model.tree_
-#     for a, b in pairs:
-#         idx_a = int(np.where(labels == a)[0][0])
-#         idx_b = int(np.where(labels == b)[0][0])
-#         path = _tree_path(tree, idx_a, idx_b)
-#         if path is None:
-#             continue
-#         path_labels = labels[path]
-#         # Summarize: count of each digit along the path
-#         unique, counts = np.unique(path_labels, return_counts=True)
-#         digit_counts = " ".join(f"{d}x{c}" for d, c in zip(unique, counts))
-#         print(f"\n  Path {a}→{b}: {len(path)} nodes [{digit_counts}]")
-
-
-# def _tree_path(tree, start: int, end: int) -> list[int] | None:
-#     """BFS to find the unique path between two nodes in a tree."""
-#     from collections import deque
-
-#     adj: dict[int, list[int]] = {}
-#     for s, t in tree.edges:
-#         adj.setdefault(int(s), []).append(int(t))
-#         adj.setdefault(int(t), []).append(int(s))
-
-#     visited = {start}
-#     queue: deque[tuple[int, list[int]]] = deque([(start, [start])])
-#     while queue:
-#         node, path = queue.popleft()
-#         if node == end:
-#             return path
-#         for neighbor in adj.get(node, []):
-#             if neighbor not in visited:
-#                 visited.add(neighbor)
-#                 queue.append((neighbor, path + [neighbor]))
-#     return None
+    pairs = [(3, 8), (4, 9), (7, 1), (5, 6)]
+    for a, b in pairs:
+        idx_a = int(np.where(labels == a)[0][0])
+        idx_b = int(np.where(labels == b)[0][0])
+        path = model.path(idx_a, idx_b)
+        path_labels = labels[path]
+        unique, counts = np.unique(path_labels, return_counts=True)
+        digit_counts = " ".join(f"{d}x{c}" for d, c in zip(unique, counts))
+        print(f"\n  Path {a}→{b}: {len(path)} nodes [{digit_counts}]")
 
 
 if __name__ == "__main__":

--- a/examples/molecules_tmap.py
+++ b/examples/molecules_tmap.py
@@ -1,17 +1,15 @@
-"""Build a molecule TMAP from examples/cluster_65053.csv.
+"""High-level molecular TMAP from a SMILES CSV.
 
-This is the clearest chemistry example in the repo:
+The simplest chemistry example: load SMILES, compute fingerprints and
+properties using domain utilities, fit a TMAP, and export an interactive
+HTML visualization.
 
-1. Load SMILES from a CSV
-2. Compute Morgan fingerprints
-3. Compute a few molecular properties and Murcko scaffolds
-4. Fit `TMAP(metric="jaccard")`
-5. Explore the result in HTML or with `serve()`
+For the step-by-step low-level pipeline, see smiles_tmap.py.
 
 Usage:
-    python examples/cluster_65053_tmap.py
-    python examples/cluster_65053_tmap.py --nrows 3000
-    python examples/cluster_65053_tmap.py --serve
+    python examples/molecules_tmap.py
+    python examples/molecules_tmap.py --nrows 3000
+    python examples/molecules_tmap.py --serve
 """
 
 from __future__ import annotations
@@ -29,7 +27,7 @@ DEFAULT_OUTPUT = Path(__file__).with_name("cluster_65053.html")
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Build a TMAP for cluster_65053 molecules.")
+    parser = argparse.ArgumentParser(description="High-level molecular TMAP.")
     parser.add_argument(
         "--nrows",
         type=int,

--- a/examples/pet_breed_audit.py
+++ b/examples/pet_breed_audit.py
@@ -168,25 +168,13 @@ def _encode_images(split: str, size: int = 128) -> list[str]:
 
 
 def _build_tmap(embeddings: np.ndarray) -> TMAP:
-    """Build a TMAP from cosine-distance on embeddings.
-
-    Uses a precomputed distance matrix (simple for small datasets).
-    ~3.7k points → ~54 MB matrix, trivially fits in memory.
-    """
-    # Cosine distance = 1 - cosine_similarity
-    norms = np.linalg.norm(embeddings, axis=1, keepdims=True)
-    norms = np.maximum(norms, 1e-8)
-    normed = embeddings / norms
-    dist = 1.0 - normed @ normed.T
-    np.clip(dist, 0, 2, out=dist)  # numerical safety
-    np.fill_diagonal(dist, 0.0)
-
+    """Build a TMAP from cosine similarity on embeddings."""
     model = TMAP(
         n_neighbors=15,
-        metric="precomputed",
+        metric="cosine",
         layout_iterations=1000,
     )
-    model.fit(dist.astype(np.float32))
+    model.fit(embeddings.astype(np.float32))
     return model
 
 
@@ -259,7 +247,8 @@ def _analyze_tree(
     w = lines.append
 
     acc = (preds == true_labels).mean()
-    w(f"Oxford-IIIT Pets Classifier Audit  ({len(true_labels)} test images, {len(class_names)} breeds)")
+    w(f"Oxford-IIIT Pets Classifier Audit  "
+      f"({len(true_labels)} test images, {len(class_names)} breeds)")
     w(f"Overall accuracy: {acc:.1%}\n")
 
     # 1. Boundary edges
@@ -278,7 +267,8 @@ def _analyze_tree(
         if pair_counts[i] == 0:
             break
         r, c = upper[0][i], upper[1][i]
-        w(f"   {class_names[classes[r]]:>30s}  <->  {class_names[classes[c]]:<30s}  ({pair_counts[i]} edges)")
+        w(f"   {class_names[classes[r]]:>30s}  <->  "
+          f"{class_names[classes[c]]:<30s}  ({pair_counts[i]} edges)")
     w("")
 
     # 3. Confidence gradients
@@ -298,8 +288,10 @@ def _analyze_tree(
     paths = _find_best_failure_paths(tree, true_labels, preds, confidences, class_names)
     w(f"5. Top failure paths ({len(paths)} shown):")
     for p in paths:
-        w(f"   Node {p['from']} ({p['true_class']}, predicted {p['pred_class']}, conf={p['conf_start']:.2f})")
-        w(f"     -> Node {p['to']} (correct, conf={p['conf_end']:.2f})  path_len={p['path_length']}  min_conf={p['conf_min']:.2f}")
+        w(f"   Node {p['from']} ({p['true_class']}, "
+          f"predicted {p['pred_class']}, conf={p['conf_start']:.2f})")
+        w(f"     -> Node {p['to']} (correct, conf={p['conf_end']:.2f})  "
+          f"path_len={p['path_length']}  min_conf={p['conf_min']:.2f}")
     w("")
 
     # 6. Mislabel candidates
@@ -398,7 +390,9 @@ def main() -> None:
 
     # Visualization
     print("Building visualization...")
-    viz = _create_visualization(model, class_names, test_labels, preds, confidences, purity, image_uris)
+    viz = _create_visualization(
+        model, class_names, test_labels, preds, confidences, purity, image_uris,
+    )
     html_path = viz.write_html(OUTPUT_DIR / "pets_tmap")
     print(f"HTML saved to {html_path}")
 

--- a/examples/smiles_tmap.py
+++ b/examples/smiles_tmap.py
@@ -1,229 +1,98 @@
-"""
-End-to-end TMAP visualization from SMILES strings.
+"""Low-level TMAP pipeline from SMILES strings.
 
-This script demonstrates the full pipeline:
-    SMILES -> Morgan Fingerprints -> MinHash -> LSHForest -> Layout -> Visualization
+Demonstrates each step of the pipeline explicitly:
+    SMILES → Morgan fingerprints → MinHash → LSHForest → OGDF layout → TmapViz
+
+For a simpler high-level approach, see molecules_tmap.py which uses the
+TMAP estimator to do all of this in a few lines.
 
 Requirements:
-    pip install rdkit tqdm
+    pip install rdkit
 
 Usage:
     python examples/smiles_tmap.py
-    # Or with custom SMILES list:
-    from examples.smiles_tmap import create_tmap_from_smiles
-    coords = create_tmap_from_smiles(my_smiles_list, "output.html")
 """
+
+from __future__ import annotations
 
 from pathlib import Path
 
-import numpy as np
 import pandas as pd
-from tqdm import tqdm
 
-# Check RDKit availability
-try:
-    from rdkit import Chem
-    from rdkit.Chem import Descriptors, rdFingerprintGenerator, rdMolDescriptors
-    RDKIT_AVAILABLE = True
-except ImportError:
-    RDKIT_AVAILABLE = False
-
-from tmap import LSHForest, MinHash
+from tmap import LSHForest, MinHash, fingerprints_from_smiles, molecular_properties
 from tmap.layout import LayoutConfig, ScalingType, layout_from_lsh_forest
 from tmap.visualization import TmapViz
 
-
-def smiles_to_fingerprints(
-    smiles_list: list[str],
-    radius: int = 2,
-    n_bits: int = 2048,
-) -> tuple[np.ndarray, list[int], list]:
-    """
-    Convert SMILES strings to Morgan fingerprints.
-
-    Args:
-        smiles_list: List of SMILES strings
-        radius: Morgan fingerprint radius (default 2 = ECFP4)
-        n_bits: Number of bits in fingerprint
-
-    Returns:
-        fingerprints: numpy array of shape (n_valid, n_bits)
-        valid_indices: indices of successfully parsed SMILES
-        mols: list of RDKit molecule objects
-    """
-    if not RDKIT_AVAILABLE:
-        raise ImportError("RDKit is required: pip install rdkit")
-
-    # Use the newer MorganGenerator API
-    morgan_gen = rdFingerprintGenerator.GetMorganGenerator(radius=radius, fpSize=n_bits)
-
-    fingerprints = []
-    valid_indices = []
-    mols = []
-
-    for i, smi in tqdm(enumerate(smiles_list),
-                       desc='Generating Fingerprints', total=len(smiles_list)):
-        mol = Chem.MolFromSmiles(smi)
-        if mol is not None:
-            fp = morgan_gen.GetFingerprintAsNumPy(mol)
-            fingerprints.append(fp.astype(np.uint8))
-            valid_indices.append(i)
-            mols.append(mol)
-
-    return np.array(fingerprints), valid_indices, mols
+DATA_PATH = Path(__file__).with_name("cluster_65053.csv")
 
 
-def compute_molecular_properties(mols: list) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-    """Compute molecular properties for coloring."""
-    mw = [Descriptors.MolWt(mol) for mol in mols] # type: ignore
-    logp = [Descriptors.MolLogP(mol) for mol in mols] # type: ignore
-    n_rings = [rdMolDescriptors.CalcNumRings(mol) for mol in mols]
-    return np.array(mw), np.array(logp), np.array(n_rings)
+def main() -> None:
+    # 1. Load SMILES and compute fingerprints
+    df = pd.read_csv(DATA_PATH)
+    smiles = df["smiles"].tolist()
+    print(f"Loaded {len(smiles):,} molecules")
 
+    fps = fingerprints_from_smiles(smiles, fp_type="morgan", radius=2, n_bits=2048)
+    n = fps.shape[0]
+    print(f"  Valid fingerprints: {n} x {fps.shape[1]}")
 
-def create_tmap_from_smiles(
-    smiles: list[str],
-    output_path: str = "tmap_molecules.html",
-    title: str = "TMAP Visualization",
-    k: int = 20,
-    kc: int = 100,
-    num_perm: int = 128,
-    seed: int = 42,
-):
-    """
-    Create a TMAP visualization from SMILES strings.
+    # 2. MinHash encoding
+    #    Converts binary fingerprints into compact hash signatures for
+    #    fast approximate Jaccard similarity search.
+    num_perm = 128
+    mh = MinHash(num_perm=num_perm, seed=42)
+    signatures = mh.batch_from_binary_array(fps)
+    print(f"  MinHash signatures: {signatures.shape}")
 
-    Args:
-        smiles: List of SMILES strings
-        output_path: Path to save HTML file
-        title: Title for the visualization
-        k: Number of nearest neighbors for k-NN graph
-        kc: Search quality multiplier
-        num_perm: Number of MinHash permutations
-        seed: Random seed for reproducibility
-
-    Returns:
-        Tuple of (x, y) coordinates
-    """
-    print(f"Processing {len(smiles)} SMILES...")
-
-    # Step 1: Convert SMILES to fingerprints
-    print("Step 1: Computing Morgan fingerprints...")
-    fingerprints, valid_indices, mols = smiles_to_fingerprints(smiles)
-    n = len(valid_indices)
-    print(f"  Valid molecules: {n}/{len(smiles)}")
-
-    if n < 2:
-        raise ValueError("Need at least 2 valid molecules")
-
-    # Get valid SMILES
-    valid_smiles = [smiles[i] for i in valid_indices]
-
-    # Step 2: Compute molecular properties
-    print("Step 2: Computing molecular properties...")
-    mw, logp, n_rings = compute_molecular_properties(mols)
-
-    # Step 3: MinHash encoding
-    print("Step 3: Encoding with MinHash...")
-    mh = MinHash(num_perm=num_perm, seed=seed)
-    signatures = mh.batch_from_binary_array(fingerprints)
-    print(f"  Signature shape: {signatures.shape}")
-
-    # Step 4: Build LSH Forest
-    print("Step 4: Building LSH Forest...")
+    # 3. Build LSH Forest index
+    #    Locality-sensitive hashing index for fast approximate kNN queries.
+    #    d = number of permutations, l = number of hash tables.
     lsh = LSHForest(d=num_perm, l=64)
     lsh.batch_add(signatures)
     lsh.index()
+    print(f"  LSH Forest indexed ({lsh.size()} points)")
 
-    # Step 5: Compute layout
-    print("Step 5: Computing layout...")
-
+    # 4. Compute OGDF layout
+    #    layout_from_lsh_forest queries the kNN graph internally,
+    #    computes an MST, and runs the OGDF tree layout algorithm.
+    #    Returns (x, y, edge_sources, edge_targets).
     cfg = LayoutConfig()
-    cfg.k = k
-    cfg.kc = kc
-    cfg.node_size = 1/30
+    cfg.k = 20
+    cfg.kc = 50
+    cfg.node_size = 1 / 30
     cfg.mmm_repeats = 2
     cfg.sl_extra_scaling_steps = 10
     cfg.sl_scaling_type = ScalingType.RelativeToDrawing
     cfg.fme_iterations = 1000
     cfg.deterministic = True
-    cfg.seed = seed
+    cfg.seed = 42
 
     x, y, s, t = layout_from_lsh_forest(lsh, cfg)
+    print(f"  Layout: {len(x)} nodes, {len(s)} edges")
 
-    print(f"  Nodes: {len(x)}")
-    print(f"  Edges: {len(s)} (fully connected tree has {n-1} edges)")
+    # 5. Build visualization
+    #    TmapViz takes pre-computed coordinates and edges directly.
+    props = molecular_properties(smiles, properties=["mw", "logp", "n_rings"])
 
-    # Step 6: Create visualization
-    print("Step 6: Creating visualization...")
     viz = TmapViz()
-    viz.title = title
+    viz.title = "Molecular TMAP (low-level pipeline)"
     viz.background_color = "#FFFFFF"
-    viz.point_color = "#4a9eff"
-    viz.point_size = 4.0
-    viz.opacity = 0.9
-
-    # Set coordinates
     viz.set_points(x, y)
+    viz.set_edges(s, t)
 
-    # Add SMILES for structure rendering
-    viz.add_smiles(valid_smiles)
-
-    # Add molecular properties as color layouts
-    viz.add_color_layout("Molecular Weight", mw.tolist(), categorical=False, color="viridis")
-    viz.add_color_layout("LogP", logp.tolist(), categorical=False, color="plasma")
-    viz.add_color_layout("Number of Rings", n_rings.tolist(), categorical=False, color="coolwarm")
-
-    # Add index labels
-    viz.add_label("Index", [str(i) for i in range(n)])
-
-    # Save visualization
-    saved_path = viz.write_html(output_path)
-    print(f"\nSaved visualization to: {saved_path}")
-    return x, y
-
-
-
-# Get the directory where this script is located
-script_dir = Path(__file__).parent
-csv_path = script_dir / 'cluster_65053.csv'
-df = pd.read_csv(csv_path)
-EXAMPLE_SMILES = df.smiles.to_list()
-
-if __name__ == "__main__":
-    if not RDKIT_AVAILABLE:
-        print("RDKit is required for this example.")
-        print("Install with: pip install rdkit")
-        exit(1)
-
-    # Create more data by adding variations
-    smiles_list = EXAMPLE_SMILES.copy()
-
-    # Add some simple modifications to increase dataset size
-    for smi in EXAMPLE_SMILES[:15]:
-        mol = Chem.MolFromSmiles(smi)
-        if mol:
-            # Add methylated versions
-            smiles_list.append(smi.replace("c1", "Cc1", 1))
-            # Add hydroxylated versions
-            smiles_list.append(smi.replace("c1", "Oc1", 1))
-
-    # Filter valid SMILES
-    valid_smiles = [s for s in smiles_list if Chem.MolFromSmiles(s) is not None]
-    print(f"Working with {len(valid_smiles)} molecules")
-
-    # Create visualization
-    coords = create_tmap_from_smiles(
-        smiles=valid_smiles,
-        output_path="tmap_molecules.html",
-        title="Molecular TMAP Demo",
-        k=20,
-        num_perm=128,
-        seed=42,
+    viz.add_smiles(smiles)
+    viz.add_color_layout("MW", props["mw"].tolist(), color="viridis")
+    viz.add_color_layout("LogP", props["logp"].tolist(), color="plasma")
+    viz.add_color_layout(
+        "Ring Count",
+        props["n_rings"].tolist(),
+        categorical=True,
+        color="tab10",
     )
 
-    print("\nDone! Open the HTML file in a browser to view the interactive visualization.")
-    print("  - Pan: Click and drag")
-    print("  - Zoom: Scroll wheel")
-    print("  - Hover: See molecule structure and properties")
-    print("  - Use dropdown to change color scheme")
+    out = viz.write_html(str(DATA_PATH.with_suffix(".html")))
+    print(f"\nSaved: {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/tmap/utils/chemistry.py
+++ b/src/tmap/utils/chemistry.py
@@ -1,5 +1,5 @@
 """Parallel chemistry utilities for fingerprint and property computation.
-Requires ``rdkit`` (install via ``pip install tmap[chemistry]``).
+Requires ``rdkit`` (install via ``pip install rdkit``).
 """
 
 from __future__ import annotations

--- a/src/tmap/utils/singlecell.py
+++ b/src/tmap/utils/singlecell.py
@@ -3,7 +3,7 @@
 Bridge between the scverse/AnnData ecosystem and TMAP. Provides helpers
 to extract matrices, cell metadata, and gene scores from AnnData objects.
 
-Requires ``anndata`` (install via ``pip install tmap[singlecell]``).
+Requires ``anndata`` (install via ``pip install anndata``).
 """
 
 from __future__ import annotations


### PR DESCRIPTION
- pet_breed_audit: use metric="cosine" instead of manual distance matrix
- mnist_cosine_tmap: remove commented-out code, use model.path()
- smiles_tmap: rewrite as low-level pipeline demo (MinHash/LSHForest)
- molecules_tmap: rename from cluster_65053_tmap, high-level counterpart
- Fix bogus pip install tmap[chemistry] and tmap[singlecell] references
- Add examples/README.md organized by domain