### PR TITLE
v0.2.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,10 +118,15 @@ from tmap.utils.singlecell import from_anndata
 |----------|-------|
 | [01 Quick Start](notebooks/01_quickstart.ipynb) | End-to-end walkthrough |
 | [02 MinHash Deep Dive](notebooks/02_minhash_deep_dive.ipynb) | Encoding methods and when to use each |
+| [03 Legacy LSH Pipeline](notebooks/03_legacy_lsh_pipeline.ipynb) | Lower-level MinHash + LSHForest + layout workflow |
 | [04 Notebook Widgets](notebooks/04_jscatter_demo.ipynb) | Selection, filtering, zoom, export |
+| [05 Single-Cell](notebooks/05_single_cell.ipynb) | RNA-seq with PBMC 3k, pseudotime, UMAP comparison |
 | [06 Metric Guide](notebooks/06_metric_guide.ipynb) | Choosing the right metric |
+| [07 FAQ](notebooks/07_faq.ipynb) | Troubleshooting and common questions |
 | [08 Cheminformatics](notebooks/08_cheminformatics.ipynb) | Molecules, fingerprints, SAR |
 | [09 Protein Analysis](notebooks/09_protein_analysis.ipynb) | FASTA, ESM embeddings, AlphaFold |
+| [11 Card Configuration](notebooks/11_card_configuration.ipynb) | Pinned card layout, fields, and links |
+| [11 Default Params Benchmark](notebooks/11_default_params_benchmark.ipynb) | Defaults across dataset sizes and types |
 | [12 USearch Jaccard](notebooks/12_usearch_jaccard.ipynb) | Binary Jaccard with USearch backend |
 
 ## Lower-Level Pipeline

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "tmap2"
-version = "0.1.0"
+version = "0.2.0"
 description = "Tree-based visualization for high-dimensional data"
 readme = "README.md"
 license = {text = "MIT"}
@@ -16,7 +16,7 @@ authors = [
     { name = "Alejandro Flores", email = "afloresep01@gmail.com" }
 ]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 4 - Beta",
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
@@ -39,8 +39,12 @@ dependencies = [
 
 [project.optional-dependencies]
 notebook = ["jupyter-scatter>=0.22.2"]
+chemistry = ["rdkit>=2023.3"]
+singlecell = ["anndata>=0.10"]
 all = [
     "jupyter-scatter>=0.22.2",
+    "rdkit>=2023.3",
+    "anndata>=0.10",
 ]
 dev = [
     "pytest>=7.0",

--- a/src/tmap/__init__.py
+++ b/src/tmap/__init__.py
@@ -41,9 +41,16 @@ if TYPE_CHECKING:
         read_protein_csv,
         sequence_properties,
     )
-    from tmap.utils.singlecell import cell_metadata, from_anndata, marker_scores
+    from tmap.utils.singlecell import (
+        cell_metadata,
+        from_anndata,
+        marker_scores,
+        obs_to_numeric,
+        sample_obs_indices,
+        subset_anndata,
+    )
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 __all__ = [
     "__version__",
@@ -59,6 +66,7 @@ __all__ = [
     "from_anndata",
     "marker_scores",
     "molecular_properties",
+    "obs_to_numeric",
     "murcko_scaffolds",
     "reaction_properties",
     "parse_alignment",
@@ -70,6 +78,8 @@ __all__ = [
     "read_pdb",
     "read_pdb_dir",
     "read_protein_csv",
+    "sample_obs_indices",
+    "subset_anndata",
 ]
 
 _LAZY_IMPORTS: dict[str, str] = {
@@ -84,6 +94,9 @@ _LAZY_IMPORTS: dict[str, str] = {
     "cell_metadata": "tmap.utils.singlecell",
     "from_anndata": "tmap.utils.singlecell",
     "marker_scores": "tmap.utils.singlecell",
+    "obs_to_numeric": "tmap.utils.singlecell",
+    "sample_obs_indices": "tmap.utils.singlecell",
+    "subset_anndata": "tmap.utils.singlecell",
     "molecular_properties": "tmap.utils.chemistry",
     "murcko_scaffolds": "tmap.utils.chemistry",
     "reaction_properties": "tmap.utils.chemistry",


### PR DESCRIPTION
## Summary
- Bump version 0.1.0 → 0.2.0 (`pyproject.toml` + `__init__.py`)
- Promote `Development Status` to Beta
- Add `chemistry` and `singlecell` optional dependency groups
- Export new singlecell helpers (`obs_to_numeric`, `sample_obs_indices`, `subset_anndata`) at top level
- Update README notebook table

## Test plan
- [x] 531 tests pass