### PR TITLE
Release v0.2.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "tmap2"
-version = "0.2.0"
+version = "0.2.1"
 description = "Tree-based visualization for high-dimensional data"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/tmap/__init__.py
+++ b/src/tmap/__init__.py
@@ -50,7 +50,7 @@ if TYPE_CHECKING:
         subset_anndata,
     )
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 __all__ = [
     "__version__",

--- a/src/tmap/utils/chemistry.py
+++ b/src/tmap/utils/chemistry.py
@@ -267,9 +267,7 @@ def _rxn_props_batch(rxn_smiles_batch: list[str]) -> NDArray[np.float64]:
                 _sum(p_mols, lambda m: m.GetNumHeavyAtoms())
                 - _sum(r_mols, lambda m: m.GetNumHeavyAtoms())
             ),
-            "delta_rings": (
-                _sum(p_mols, _nrings) - _sum(r_mols, _nrings)
-            ),
+            "delta_rings": (_sum(p_mols, _nrings) - _sum(r_mols, _nrings)),
             "delta_aromatic_rings": (
                 _sum(p_mols, rdMolDescriptors.CalcNumAromaticRings)
                 - _sum(r_mols, rdMolDescriptors.CalcNumAromaticRings)

--- a/tests/test_minhash.py
+++ b/tests/test_minhash.py
@@ -562,9 +562,10 @@ class TestWeightedMinHashIntegration:
         wmh = WeightedMinHash(dim=100, num_perm=128, seed=42)
 
         # Simulate two documents with word counts
-        doc1 = np.random.uniform(0.1, 10, size=100)
+        rng = np.random.default_rng(42)
+        doc1 = rng.uniform(0.1, 10, size=100)
         doc2 = doc1.copy()
-        doc2[:10] = np.random.uniform(0.1, 10, size=10)  # Modify first 10 words
+        doc2[:10] = rng.uniform(0.1, 10, size=10)  # Modify first 10 words
 
         sig1 = wmh.from_weight_array(doc1)
         sig2 = wmh.from_weight_array(doc2)


### PR DESCRIPTION
## Summary
- Bump version to 0.2.1 (`pyproject.toml`, `src/tmap/__init__.py`)

Changes since v0.2.0:
- f6d139e pump smilesdrawer version
- e324078 fix map4
- 2c2f423, 2e2dd51 update notebooks

Tag `v0.2.1` will be pushed after merge to trigger PyPI publish via `.github/workflows/publish.yml`.

## Test plan
- [ ] CI status checks pass
- [ ] After merge: tag `v0.2.1` and verify PyPI publish workflow succeeds