### PR TITLE
Let fingerprints_from_smiles report which SMILES it kept

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -152,7 +152,7 @@ These live in `tmap.utils`.
 
 | Function | What it does |
 |----------|---------------|
-| `fingerprints_from_smiles(smiles, fp_type="morgan", ...)` | Build fingerprints from SMILES |
+| `fingerprints_from_smiles(smiles, fp_type="morgan", ..., return_valid=False)` | Build fingerprints from SMILES |
 | `molecular_properties(smiles, properties=None)` | Compute RDKit properties |
 | `murcko_scaffolds(smiles)` | Compute Murcko scaffold strings |
 
@@ -162,6 +162,19 @@ These live in `tmap.utils`.
 from tmap.utils import fingerprints_from_smiles, molecular_properties
 
 fps = fingerprints_from_smiles(smiles, fp_type="morgan", radius=2, n_bits=2048)
+props = molecular_properties(smiles, properties=["mw", "logp", "n_rings"])
+```
+
+`fingerprints_from_smiles` skips any SMILES it cannot read, so it can give
+back fewer rows than you passed in. `molecular_properties` and
+`murcko_scaffolds` keep every input and fill the bad ones with `NaN` or `""`.
+If a SMILES might be bad, ask for the flags and drop those inputs first.
+Otherwise the lists stop matching and points get the wrong colors and labels:
+
+```python
+fps, valid = fingerprints_from_smiles(smiles, return_valid=True)
+smiles = [smi for smi, ok in zip(smiles, valid) if ok]
+
 props = molecular_properties(smiles, properties=["mw", "logp", "n_rings"])
 ```
 

--- a/docs/molecule_tutorial.md
+++ b/docs/molecule_tutorial.md
@@ -35,12 +35,21 @@ Use a small subset first. Once the workflow is working, remove `nrows=3000`.
 ```python
 from tmap.utils import fingerprints_from_smiles, molecular_properties, murcko_scaffolds
 
-fps = fingerprints_from_smiles(smiles, fp_type="morgan", radius=2, n_bits=2048)
+fps, valid = fingerprints_from_smiles(
+    smiles, fp_type="morgan", radius=2, n_bits=2048, return_valid=True
+)
+
+# Only readable SMILES get a fingerprint. Drop the rest, so the properties,
+# scaffolds and tooltips still belong to the right molecules.
+smiles = [smi for smi, ok in zip(smiles, valid) if ok]
+
 props = molecular_properties(smiles, properties=["mw", "logp", "n_rings", "qed"])
 scaffolds = murcko_scaffolds(smiles)
 ```
 
 `fingerprints_from_smiles` returns a binary matrix for `metric="jaccard"`.
+Without `return_valid=True` you get just the matrix, and a single bad SMILES
+shifts every row after it in `props` and `scaffolds`.
 
 ## 3. Fit TMAP
 

--- a/examples/chemistry/molecules_tmap.py
+++ b/examples/chemistry/molecules_tmap.py
@@ -71,7 +71,16 @@ def main() -> None:
     print(f"Loaded {len(smiles):,} molecules from {DATA_PATH.name}")
 
     print("Computing Morgan fingerprints...")
-    fps = fingerprints_from_smiles(smiles, fp_type="morgan", radius=2, n_bits=2048)
+    fps, valid = fingerprints_from_smiles(
+        smiles, fp_type="morgan", radius=2, n_bits=2048, return_valid=True
+    )
+
+    # A SMILES that cannot be read gets no fingerprint, so drop it here.
+    # Otherwise the properties, scaffolds and tooltips computed below would
+    # end up attached to the wrong molecules.
+    if not valid.all():
+        print(f"  Dropping {int((~valid).sum()):,} unparseable SMILES")
+        smiles = [smi for smi, ok in zip(smiles, valid) if ok]
 
     print("Computing molecular properties...")
     props = molecular_properties(smiles, properties=["mw", "logp", "n_rings", "qed"])

--- a/examples/chemistry/molecules_tmap_legacy.py
+++ b/examples/chemistry/molecules_tmap_legacy.py
@@ -27,7 +27,15 @@ def main() -> None:
     print(f"Loaded {len(smiles):,} molecules from {DATA_PATH.name}")
 
     print("Computing Morgan fingerprints...")
-    fps = fingerprints_from_smiles(smiles, fp_type="morgan", radius=2, n_bits=2048)
+    fps, valid = fingerprints_from_smiles(
+        smiles, fp_type="morgan", radius=2, n_bits=2048, return_valid=True
+    )
+
+    # Drop the SMILES that could not be read, so everything computed below
+    # still belongs to the right molecule.
+    if not valid.all():
+        print(f"  Dropping {int((~valid).sum()):,} unparseable SMILES")
+        smiles = [smi for smi, ok in zip(smiles, valid) if ok]
 
     print("Computing molecular properties...")
     props = molecular_properties(smiles, properties=["mw", "logp", "n_rings", "qed"])

--- a/examples/chemistry/smiles_tmap.py
+++ b/examples/chemistry/smiles_tmap.py
@@ -36,7 +36,12 @@ def main() -> None:
     smiles = df["smiles"].tolist()
     print(f"Loaded {len(smiles):,} molecules")
 
-    fps = fingerprints_from_smiles(smiles, fp_type="morgan", radius=2, n_bits=2048)
+    fps, valid = fingerprints_from_smiles(
+        smiles, fp_type="morgan", radius=2, n_bits=2048, return_valid=True
+    )
+    # A SMILES that cannot be read gets no fingerprint, and so no point on the
+    # map. Drop it, so the list still matches the coordinates worked out below.
+    smiles = [smi for smi, ok in zip(smiles, valid) if ok]
     n = fps.shape[0]
     print(f"  Valid fingerprints: {n} x {fps.shape[1]}")
 

--- a/src/tmap/utils/chemistry.py
+++ b/src/tmap/utils/chemistry.py
@@ -90,75 +90,82 @@ def _init_props_worker(prop_names: list[str]) -> None:
 # Fingerprint batch functions (called inside Pool workers)
 
 
-def _morgan_fp_batch(smiles_batch: list[str]) -> NDArray[np.uint8]:
-    """Process a batch of SMILES, return fps array for valid entries."""
+def _morgan_fp_batch(smiles_batch: list[str]) -> tuple[NDArray[np.uint8], NDArray[np.bool_]]:
+    """Process a batch of SMILES, return the fingerprints plus one True/False flag per input."""
     from rdkit import Chem
     from rdkit.Chem import rdFingerprintGenerator
 
     gen = rdFingerprintGenerator.GetMorganGenerator(radius=_FP_RADIUS, fpSize=_FP_NBITS)
     fps = []
-    for smi in smiles_batch:
+    valid = np.zeros(len(smiles_batch), dtype=bool)
+    for i, smi in enumerate(smiles_batch):
         if not smi:
             continue
         mol = Chem.MolFromSmiles(smi)
         if mol is not None:
             fps.append(gen.GetFingerprintAsNumPy(mol).astype(np.uint8))
+            valid[i] = True
     if fps:
-        return np.stack(fps)
-    return np.empty((0, _FP_NBITS), dtype=np.uint8)
+        return np.stack(fps), valid
+    return np.empty((0, _FP_NBITS), dtype=np.uint8), valid
 
 
-def _mqn_fp_batch(smiles_batch: list[str]) -> NDArray[np.int16]:
-    """Process a batch of SMILES, return MQN fingerprints (42 integer counts) for valid entries."""
+def _mqn_fp_batch(smiles_batch: list[str]) -> tuple[NDArray[np.int16], NDArray[np.bool_]]:
+    """Process a batch of SMILES, return MQN fingerprints (42 counts) plus one flag per input."""
     from rdkit import Chem
     from rdkit.Chem import rdMolDescriptors
 
     fps = []
-    for smi in smiles_batch:
+    valid = np.zeros(len(smiles_batch), dtype=bool)
+    for i, smi in enumerate(smiles_batch):
         if not smi:
             continue
         mol = Chem.MolFromSmiles(smi)
         if mol is not None:
             fps.append(np.array(rdMolDescriptors.MQNs_(mol), dtype=np.int16))
+            valid[i] = True
     if fps:
-        return np.stack(fps)
-    return np.empty((0, 42), dtype=np.int16)
+        return np.stack(fps), valid
+    return np.empty((0, 42), dtype=np.int16), valid
 
 
-def _mxfp_fp_batch(smiles_batch: list[str]) -> NDArray[np.int64]:
-    """Process a batch of SMILES, return MXFP fingerprints (217-dim counts) for valid entries."""
+def _mxfp_fp_batch(smiles_batch: list[str]) -> tuple[NDArray[np.int64], NDArray[np.bool_]]:
+    """Process a batch of SMILES, return MXFP fingerprints (217-dim) plus one flag per input."""
     from mxfp.mxfp import MXFPCalculator
 
     calc = MXFPCalculator()
     fps = []
-    for smi in smiles_batch:
+    valid = np.zeros(len(smiles_batch), dtype=bool)
+    for i, smi in enumerate(smiles_batch):
         if not smi:
             continue
         try:
             fp = calc.mxfp_from_smiles(smi)
             if fp is not None:
                 fps.append(fp)
+                valid[i] = True
         except Exception:
             pass
     if fps:
-        return np.stack(fps)
-    return np.empty((0, 217), dtype=np.int64)
+        return np.stack(fps), valid
+    return np.empty((0, 217), dtype=np.int64), valid
 
 
-def _drfp_fp_batch(smiles_batch: list[str]) -> NDArray[np.uint8]:
-    """Process a batch of reaction SMILES, return DRFP fingerprints for the batch."""
+def _drfp_fp_batch(smiles_batch: list[str]) -> tuple[NDArray[np.uint8], NDArray[np.bool_]]:
+    """Process a batch of reaction SMILES, return DRFP fingerprints plus one flag per input."""
     from drfp import DrfpEncoder
 
+    valid = np.array([bool(smi) for smi in smiles_batch], dtype=bool)
     clean = [smi for smi in smiles_batch if smi]
     if not clean:
         n_bits = _DRFP_PARAMS.get("n_folded_length", 2048)
-        return np.empty((0, n_bits), dtype=np.uint8)
+        return np.empty((0, n_bits), dtype=np.uint8), valid
     fps_list = DrfpEncoder.encode(clean, **_DRFP_PARAMS)
-    return np.array(fps_list, dtype=np.uint8)
+    return np.array(fps_list, dtype=np.uint8), valid
 
 
-def _mhfp_fp_batch(smiles_batch: list[str]) -> NDArray[np.uint8]:
-    """Process a batch of SMILES, return SECFP (folded MHFP) fingerprints for valid entries.
+def _mhfp_fp_batch(smiles_batch: list[str]) -> tuple[NDArray[np.uint8], NDArray[np.bool_]]:
+    """Process a batch of SMILES, return SECFP fingerprints plus one flag per input.
 
     SECFP is MHFP's folded binary variant: a uint8 {0,1} vector suitable
     for the Jaccard-on-binary path used by the other fingerprint types.
@@ -169,7 +176,8 @@ def _mhfp_fp_batch(smiles_batch: list[str]) -> NDArray[np.uint8]:
     encoder = MHFPEncoder()
     length = _MHFP_PARAMS.get("length", 2048)
     fps: list[NDArray[np.uint8]] = []
-    for smi in smiles_batch:
+    valid = np.zeros(len(smiles_batch), dtype=bool)
+    for i, smi in enumerate(smiles_batch):
         if not smi:
             continue
         mol = Chem.MolFromSmiles(smi)
@@ -185,9 +193,10 @@ def _mhfp_fp_batch(smiles_batch: list[str]) -> NDArray[np.uint8]:
         )
         if fp is not None:
             fps.append(np.asarray(fp, dtype=np.uint8))
+            valid[i] = True
     if fps:
-        return np.stack(fps)
-    return np.empty((0, length), dtype=np.uint8)
+        return np.stack(fps), valid
+    return np.empty((0, length), dtype=np.uint8), valid
 
 
 # Property batch functions (called inside Pool workers)
@@ -295,6 +304,18 @@ def _default_n_workers() -> int:
     return min(os.cpu_count() or 1, 12)
 
 
+def _warn_dropped(valid: NDArray[np.bool_]) -> None:
+    """Log a warning when some SMILES could not be read."""
+    n_dropped = int((~valid).sum())
+    if n_dropped:
+        logger.warning(
+            "%d/%d SMILES could not be parsed and were skipped. "
+            "Pass return_valid=True to find out which ones.",
+            n_dropped,
+            len(valid),
+        )
+
+
 def _split_into_chunks(lst: list[Any], n_chunks: int) -> list[list[Any]]:
     """Split list into roughly equal chunks."""
     k, m = divmod(len(lst), n_chunks)
@@ -304,7 +325,9 @@ def _split_into_chunks(lst: list[Any], n_chunks: int) -> list[list[Any]]:
 # Fingerprint helpers with built-in parallelization (no Pool wrapper)
 
 
-def _map4_fingerprints(smiles: list[str], n_workers: int, **kwargs: Any) -> NDArray[np.uint8]:
+def _map4_fingerprints(
+    smiles: list[str], n_workers: int, **kwargs: Any
+) -> tuple[NDArray[np.uint8], NDArray[np.bool_]]:
     """Compute MAP4 fingerprints using the map4 package.
 
     MAP4 (MinHashed Atom-Pair fingerprint of radius 2) encodes molecules
@@ -333,25 +356,20 @@ def _map4_fingerprints(smiles: list[str], n_workers: int, **kwargs: Any) -> NDAr
     )
 
     mols = []
-    for smi in smiles:
+    valid = np.zeros(len(smiles), dtype=bool)
+    for i, smi in enumerate(smiles):
         if not smi:
             continue
         mol = Chem.MolFromSmiles(smi)
         if mol is not None:
             mols.append(mol)
+            valid[i] = True
 
-    n_valid = len(mols)
-    if n_valid == 0:
-        return np.empty((0, dimensions), dtype=np.uint8)
-    if n_valid < len(smiles):
-        logger.warning(
-            "%d/%d SMILES could not be parsed and were skipped.",
-            len(smiles) - n_valid,
-            len(smiles),
-        )
+    if not mols:
+        return np.empty((0, dimensions), dtype=np.uint8), valid
 
     fps = calc.calculate_many(mols, number_of_threads=n_workers)
-    return np.asarray(fps, dtype=np.uint8)
+    return np.asarray(fps, dtype=np.uint8), valid
 
 
 # fingerprints_from_smiles
@@ -361,8 +379,9 @@ def fingerprints_from_smiles(
     smiles: list[str],
     fp_type: str = "morgan",
     n_workers: int | None = None,
+    return_valid: bool = False,
     **kwargs: Any,
-) -> NDArray:
+) -> NDArray | tuple[NDArray, NDArray[np.bool_]]:
     """Compute molecular fingerprints in parallel.
 
     Parameters
@@ -394,16 +413,26 @@ def fingerprints_from_smiles(
           ``min_radius=0``, ``rings=True``.
     n_workers : int or None
         Number of parallel workers. Defaults to ``min(cpu_count, 12)``.
+    return_valid : bool, default False
+        If True, also return one True/False flag per input SMILES saying
+        whether it produced a fingerprint. Use it to line the fingerprints
+        up with :func:`molecular_properties` and :func:`murcko_scaffolds`,
+        which always return one entry per input.
     **kwargs
         Passed to the fingerprint generator.
 
     Returns
     -------
     fps : ndarray of shape ``(n_valid, n_bits)``
-        Fingerprint matrix. Invalid SMILES are silently skipped (a
-        warning is logged with the count). Dtype depends on
-        ``fp_type``: ``uint8`` for Morgan/DRFP/MAP4/MHFP, ``int16`` for
-        MQN, ``int64`` for MXFP.
+        Fingerprint matrix. Invalid SMILES are skipped (a warning is
+        logged with the count). Dtype depends on ``fp_type``: ``uint8``
+        for Morgan/DRFP/MAP4/MHFP, ``int16`` for MQN, ``int64`` for
+        MXFP.
+    valid : ndarray of shape ``(len(smiles),)``, dtype ``bool``
+        Returned only when ``return_valid=True``. ``valid[i]`` is True
+        when ``smiles[i]`` could be read. Indexing any per-input array
+        with it drops the same entries that ``fps`` is missing, so both
+        end up the same length.
 
     Examples
     --------
@@ -417,21 +446,32 @@ def fingerprints_from_smiles(
     (1, 42)
     >>> fps.dtype
     dtype('int16')
-    """
-    # Canonical shapes/dtypes per fp_type for empty returns
-    _EMPTY_SHAPES = {
-        "morgan": (2048, np.uint8),
-        "mqn": (42, np.int16),
-        "mxfp": (217, np.int64),
-        "drfp": (kwargs.get("n_folded_length", 2048), np.uint8),
-        "map4": (kwargs.get("dimensions", 1024), np.uint8),
-        "mhfp": (kwargs.get("length", 2048), np.uint8),
-    }
 
+    Unreadable SMILES get no row, so ask for the flags when other
+    per-molecule arrays have to match up:
+
+    >>> smiles = ["CCO", "not_a_molecule", "c1ccccc1"]
+    >>> fps, valid = fingerprints_from_smiles(smiles, return_valid=True)
+    >>> valid
+    array([ True, False,  True])
+    >>> fps.shape
+    (2, 2048)
+    """
     n = len(smiles)
     if n == 0:
-        ncols, dt = _EMPTY_SHAPES.get(fp_type, (0, np.uint8))
-        return np.empty((0, ncols), dtype=dt)
+        # Nothing to do, but still hand back an array of the width and type
+        # this fp_type would normally produce.
+        empty_shapes = {
+            "morgan": (kwargs.get("n_bits", 2048), np.uint8),
+            "mqn": (42, np.int16),
+            "mxfp": (217, np.int64),
+            "drfp": (kwargs.get("n_folded_length", 2048), np.uint8),
+            "map4": (kwargs.get("dimensions", 1024), np.uint8),
+            "mhfp": (kwargs.get("length", 2048), np.uint8),
+        }
+        ncols, dt = empty_shapes.get(fp_type, (0, np.uint8))
+        empty = np.empty((0, ncols), dtype=dt)
+        return (empty, np.zeros(0, dtype=bool)) if return_valid else empty
 
     if n_workers is None:
         n_workers = _default_n_workers()
@@ -439,7 +479,9 @@ def fingerprints_from_smiles(
 
     # MAP4 has built-in parallelization via calculate_many()
     if fp_type == "map4":
-        return _map4_fingerprints(smiles, n_workers=n_workers, **kwargs)
+        fps, valid = _map4_fingerprints(smiles, n_workers=n_workers, **kwargs)
+        _warn_dropped(valid)
+        return (fps, valid) if return_valid else fps
 
     # All other fingerprints use our Pool wrapper
     ctx = _get_mp_context()
@@ -493,16 +535,15 @@ def fingerprints_from_smiles(
             "Use 'morgan', 'mqn', 'mxfp', 'map4', 'mhfp', or 'drfp'."
         )
 
-    fps_parts = [r for r in batch_results if len(r) > 0]
-    if not fps_parts:
-        ncols, dt = _EMPTY_SHAPES.get(fp_type, (0, np.uint8))
-        return np.empty((0, ncols), dtype=dt)
+    # Each worker got one slice of the input list, and the slices are in order,
+    # so joining the results back together restores the original order. Workers
+    # that parsed nothing return an empty block of the right width, which joins
+    # in without changing anything.
+    fps = np.concatenate([arr for arr, _ in batch_results])
+    valid = np.concatenate([mask for _, mask in batch_results])
 
-    fps = np.concatenate(fps_parts)
-    n_valid = len(fps)
-    if n_valid < n:
-        logger.warning("%d/%d SMILES could not be parsed and were skipped.", n - n_valid, n)
-    return fps
+    _warn_dropped(valid)
+    return (fps, valid) if return_valid else fps
 
 
 # Scaffolds

--- a/tests/test_chemistry.py
+++ b/tests/test_chemistry.py
@@ -1,0 +1,91 @@
+"""Tests for tmap.utils.chemistry.
+
+These check that the three per-molecule helpers can be kept in step.
+``fingerprints_from_smiles`` skips any SMILES it cannot read, while
+``molecular_properties`` and ``murcko_scaffolds`` keep one entry for
+every input, so callers need the flags to line the results back up.
+"""
+
+import numpy as np
+import pytest
+
+rdkit = pytest.importorskip("rdkit")
+
+from tmap.utils.chemistry import (  # noqa: E402
+    fingerprints_from_smiles,
+    molecular_properties,
+    murcko_scaffolds,
+)
+
+VALID = ["CCO", "c1ccccc1", "CC(=O)O"]
+MIXED = ["CCO", "not_a_molecule", "c1ccccc1"]
+
+
+class TestReturnValidMask:
+    def test_default_returns_bare_array(self):
+        fps = fingerprints_from_smiles(VALID, n_workers=1)
+        assert isinstance(fps, np.ndarray)
+        assert fps.shape == (3, 2048)
+
+    def test_mask_has_one_entry_per_input(self):
+        fps, valid = fingerprints_from_smiles(MIXED, n_workers=1, return_valid=True)
+        assert valid.dtype == np.bool_
+        assert valid.tolist() == [True, False, True]
+        assert len(valid) == len(MIXED)
+        assert int(valid.sum()) == len(fps)
+
+    def test_all_valid_mask_is_all_true(self):
+        fps, valid = fingerprints_from_smiles(VALID, n_workers=1, return_valid=True)
+        assert valid.all()
+        assert len(fps) == len(VALID)
+
+    def test_empty_input(self):
+        fps, valid = fingerprints_from_smiles([], return_valid=True)
+        assert fps.shape == (0, 2048)
+        assert valid.shape == (0,)
+
+    def test_all_invalid(self):
+        fps, valid = fingerprints_from_smiles(["nope", ""], n_workers=1, return_valid=True)
+        assert fps.shape == (0, 2048)
+        assert not valid.any()
+        assert len(valid) == 2
+
+    def test_mask_spans_multiple_worker_chunks(self):
+        # More SMILES than workers, with bad entries in different slices, so
+        # the flags from each worker have to be joined back in input order.
+        smiles = ["CCO", "bad_1", "c1ccccc1", "bad_2", "CC(=O)O", "CCN"]
+        fps, valid = fingerprints_from_smiles(smiles, n_workers=3, return_valid=True)
+        assert valid.tolist() == [True, False, True, False, True, True]
+        assert len(fps) == 4
+
+    def test_mqn_mask(self):
+        fps, valid = fingerprints_from_smiles(MIXED, fp_type="mqn", n_workers=1, return_valid=True)
+        assert fps.shape == (2, 42)
+        assert valid.tolist() == [True, False, True]
+
+    def test_warns_about_dropped_rows(self, caplog):
+        with caplog.at_level("WARNING", logger="tmap.utils.chemistry"):
+            fingerprints_from_smiles(MIXED, n_workers=1)
+        assert "1/3" in caplog.text
+        assert "return_valid" in caplog.text
+
+
+class TestAlignmentAcrossHelpers:
+    def test_mask_realigns_properties_and_scaffolds(self):
+        fps, valid = fingerprints_from_smiles(MIXED, n_workers=1, return_valid=True)
+        props = molecular_properties(MIXED, ["mw"], n_workers=1)
+        scaffolds = murcko_scaffolds(MIXED, n_workers=1)
+
+        assert len(props["mw"]) == len(MIXED)
+        assert len(scaffolds) == len(MIXED)
+
+        mw = props["mw"][valid]
+        kept_scaffolds = scaffolds[valid]
+        assert len(mw) == len(fps) == len(kept_scaffolds)
+        assert not np.isnan(mw).any()
+
+        # Row 1 of fps is benzene, so the property left at index 1 after
+        # dropping the bad entry has to be benzene's too.
+        benzene_mw = molecular_properties(["c1ccccc1"], ["mw"], n_workers=1)["mw"][0]
+        assert mw[1] == pytest.approx(benzene_mw)
+        assert kept_scaffolds[1] == "c1ccccc1"


### PR DESCRIPTION
Fixes #38.

## The problem

`fingerprints_from_smiles` drops any SMILES it cannot read.
`molecular_properties` and `murcko_scaffolds` keep every input and fill the
bad ones with `NaN` or `""`. So one bad SMILES leaves you with arrays of
different lengths, and every row after it is shifted by one. Nothing raises,
so the map just comes out with the wrong colors and labels.

## The fix

A new `return_valid` argument, off by default:

```python
smiles = ["CCO", "not_a_molecule", "c1ccccc1"]

fps, valid = fingerprints_from_smiles(smiles, return_valid=True)
# valid -> array([ True, False,  True])

smiles = [smi for smi, ok in zip(smiles, valid) if ok]
props = molecular_properties(smiles, ["mw"])   # now the same length as fps
```

`valid` has one entry per input SMILES, and `valid.sum() == len(fps)`.

This is the first of the three options listed in the issue. It leaves the
existing return value alone, so nothing that calls the function today has to
change. The warning that gets logged when rows are dropped now mentions
`return_valid`, so the next person hits the answer rather than just the count.

## What changed

- Every fingerprint worker returns its flags alongside its fingerprints.
  Workers get consecutive slices of the input list, so joining the results
  back together restores the original order.
- The three chemistry examples had this bug live: they passed the full SMILES
  list to `molecular_properties` and `murcko_scaffolds` next to a shorter
  `fps`. They now drop the unreadable ones first.
- `docs/api_reference.md` and `docs/molecule_tutorial.md`.

## Tests

`tests/test_chemistry.py`, 9 tests: flags line up with the input, bad entries
spread across several workers are stitched back in the right order, empty and
all-bad input, and a round trip showing `props["mw"][valid]` matching `fps`
row for row.

## One small behaviour change

When every SMILES fails, the empty array returned now has the width you asked
for rather than a hardcoded default. Before, `n_bits=1024` with all input bad
returned a `(0, 2048)` array. This fell out of removing a branch that is no
longer needed, since the workers already return empty blocks of the right
width.
