### PR TITLE
Add filter panel columns without color layouts

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -129,6 +129,7 @@ Visualization object returned by `model.to_tmapviz()`.
 | Method | What it does |
 |--------|---------------|
 | `add_color_layout(name, values, ...)` | Add a colorable column |
+| `add_filter(name, values, ...)` | Add a filter-panel column without colors |
 | `add_label(name, values)` | Add a tooltip column |
 | `add_smiles(values)` | Add molecule structures to tooltips |
 | `to_widget(...)` | Build a Jupyter widget |

--- a/docs/visualization_guide.md
+++ b/docs/visualization_guide.md
@@ -111,6 +111,28 @@ viz.add_color_layout(
 
 Use this for discrete labels or small integer sets.
 
+### Filter-Only Columns
+
+```python
+viz.add_filter("MW", props["mw"].tolist())
+viz.add_filter("Ring Count", props["n_rings"].tolist(), categorical=True)
+```
+
+Use this when people should be able to filter on a column, but it does not need
+to be one of the colors they can switch between. Numbers get a slider, groups
+get one clickable bar each. Choosing colors is the slow part of
+`add_color_layout`, and this skips it, so extra filter columns cost very little.
+
+Color layouts can already be filtered on, so `add_filter` columns go into the
+panel on top of them, not instead of them. To say exactly what the panel shows,
+set `filterable`:
+
+```python
+viz.filterable = ["MW", "LogP"]
+```
+
+Pass `add_as_label=False` to keep a filter column out of the tooltip.
+
 ### Tooltip Labels
 
 ```python

--- a/src/tmap/visualization/templates/base.html.j2
+++ b/src/tmap/visualization/templates/base.html.j2
@@ -2597,7 +2597,13 @@ function getLabel(idx) {
 }
 
 function comparisonColumnNames(cardConfig) {
-  const preferred = cardConfig && cardConfig.fields ? cardConfig.fields : layoutOptions;
+  // Numbers to compare between two points. Unless the card names its own
+  // fields, use the columns the map already shows: filter panel first, then
+  // color layouts. A map built only with add_filter has no color layouts,
+  // so listing both keeps the comparison working either way.
+  const preferred = cardConfig && cardConfig.fields
+    ? cardConfig.fields
+    : [...new Set([...filterColumnNames, ...layoutOptions])];
   const result = [];
   for (const name of preferred) {
     const col = columns[name];

--- a/src/tmap/visualization/tmapviz.py
+++ b/src/tmap/visualization/tmapviz.py
@@ -247,6 +247,43 @@ def _cycle_colormaps(
             colormaps_payload[cmap_name] = [base[i % len(base)] for i in range(needed)]
 
 
+def _coerce_column_values(
+    name: str,
+    values: list[Any] | NDArray,
+    categorical: bool,
+) -> list[Any] | NDArray:
+    """Turn column values into a list or float array, rejecting text in numeric columns."""
+    if isinstance(values, np.ndarray) and not categorical:
+        values = np.asarray(values, dtype=np.float32)
+    elif isinstance(values, np.ndarray):
+        values = values.tolist()
+    else:
+        values = list(values)
+
+    if categorical:
+        return values
+
+    for v in values:
+        if v is None or (isinstance(v, str) and v == ""):
+            continue
+        # pandas NA-like sentinels
+        try:
+            import pandas as _pd
+
+            if isinstance(v, type(_pd.NA)):
+                continue
+        except ImportError:
+            pass
+        try:
+            float(v)
+        except (ValueError, TypeError):
+            raise ValueError(
+                f"Continuous column '{name}' contains non-numeric value "
+                f"{v!r}. Use categorical=True for string values."
+            ) from None
+    return values
+
+
 def _contains_nan(values: Sequence[Any]) -> bool:
     """Return True when values contain at least one NaN."""
     try:
@@ -333,7 +370,7 @@ def _to_json_safe(value: Any) -> Any:
 class Column:
     name: str
     values: Sequence[int | np.floating | str]
-    role: Literal["layout", "label", "layout+label", "smiles", "images"]
+    role: Literal["layout", "label", "layout+label", "filter", "filter+label", "smiles", "images"]
     dtype: Literal["continuous", "categorical", "label", "smiles", "images"]
     color: str | None = None
 
@@ -429,6 +466,7 @@ class TmapViz:
         self._custom_colormaps: dict[str, list[str]] = {}
 
         # UI configuration (new declarative API)
+        self._filter_keys: list[str] = []
         self._filterable: list[str] = []
         self._searchable: list[str] = []
         self._card_config: dict[str, Any] | None = None
@@ -482,35 +520,9 @@ class TmapViz:
             layouts. If None, defaults to ``"tab10"`` for categorical and
             ``"viridis"`` for continuous.
         """
-        if isinstance(values, np.ndarray) and not categorical:
-            values = np.asarray(values, dtype=np.float32)
-        elif isinstance(values, np.ndarray):
-            values = values.tolist()
-        else:
-            values = list(values)
-
         # Default to continuous because it will give less issues and having to pass
         # always the type can be annoying...
-        # Validate continuous values are actually numeric
-        if not categorical:
-            for v in values:
-                if v is None or (isinstance(v, str) and v == ""):
-                    continue
-                # pandas NA-like sentinels
-                try:
-                    import pandas as _pd
-
-                    if isinstance(v, type(_pd.NA)):
-                        continue
-                except ImportError:
-                    pass
-                try:
-                    float(v)
-                except (ValueError, TypeError):
-                    raise ValueError(
-                        f"Continuous layout '{name}' contains non-numeric value "
-                        f"{v!r}. Use categorical=True for string values."
-                    ) from None
+        values = _coerce_column_values(name, values, categorical)
 
         _column_dtype: Literal["categorical", "continuous"] = (
             "categorical" if categorical else "continuous"
@@ -678,6 +690,70 @@ class TmapViz:
                 )
 
         return color
+
+    def add_filter(
+        self,
+        name: str,
+        values: list[Any] | NDArray,
+        categorical: bool = False,
+        add_as_label: bool = True,
+    ) -> None:
+        """Add a column to the filter panel without giving it colors.
+
+        Use this when people should be able to filter on a column but it
+        does not need to be one of the colors they can switch between.
+        Picking colors is the slow part of ``add_color_layout``, and this
+        method skips it, so extra filter columns cost very little.
+
+        Parameters
+        ----------
+        name : str
+            Column name shown in the filter panel and tooltip.
+        values : list or ndarray
+            One value per point.
+        categorical : bool, default False
+            If True, treat the values as separate groups and show one
+            clickable bar per group. Otherwise the panel shows a slider
+            for the range of numbers.
+        add_as_label : bool, default True
+            Also show the values in the hover tooltip.
+
+        Raises
+        ------
+        ValueError
+            If *name* is already a color layout. Color layouts can already
+            be filtered on, so there is nothing to add. To choose exactly
+            what the panel shows, set the ``filterable`` property instead.
+
+        Notes
+        -----
+        Columns added here go into the panel on top of the color layouts,
+        not instead of them. Setting ``filterable`` replaces both.
+        """
+        if name in self._layout_keys:
+            raise ValueError(
+                f"Cannot add filter '{name}': it already exists as a color layout, "
+                "and color layouts can already be filtered on. Set the 'filterable' "
+                "property to choose exactly which columns the panel shows."
+            )
+
+        values = _coerce_column_values(name, values, categorical)
+        _column_dtype: Literal["categorical", "continuous"] = (
+            "categorical" if categorical else "continuous"
+        )
+
+        if add_as_label:
+            if name not in self._labels_keys:
+                self._labels_keys.append(name)
+            role: Literal["filter", "filter+label"] = "filter+label"
+        else:
+            if name in self._labels_keys:
+                self._labels_keys.remove(name)
+            role = "filter"
+
+        self._columns[name] = Column(name, values, role, _column_dtype)
+        if name not in self._filter_keys:
+            self._filter_keys.append(name)
 
     def add_label(
         self,
@@ -930,9 +1006,27 @@ class TmapViz:
         self._structures_3d_file_paths = file_paths
         self._structures_3d_copy_sidecars = True
 
+    def _filter_options(self) -> list[str] | None:
+        """Work out which columns the filter panel should show.
+
+        A ``filterable`` list set by hand wins. Otherwise the panel shows
+        the columns added with ``add_filter`` first, then the color
+        layouts, which have always been filterable by default.
+        """
+        if self._filterable:
+            return list(self._filterable)
+        options = list(self._filter_keys)
+        options += [name for name in self._layout_keys if name not in self._filter_keys]
+        return options or None
+
     @property
     def filterable(self) -> list[str]:
-        """Column names shown in the filter panel."""
+        """Column names shown in the filter panel.
+
+        Empty by default, which means the panel shows the columns added
+        with ``add_filter`` plus every color layout. Assigning a list
+        replaces that with exactly the columns you name.
+        """
         return list(self._filterable)
 
     @filterable.setter
@@ -1690,7 +1784,7 @@ class TmapViz:
             "hasEdgeWeights": bool(edge_weights_b64),
             "columns": columns_meta,
             "card": self._card_config,
-            "filters": self._filterable if self._filterable else (layout_options or None),
+            "filters": self._filter_options(),
             "search": self._searchable if self._searchable else (label_options or None),
         }
 
@@ -1903,7 +1997,7 @@ class TmapViz:
             "hasEdgeWeights": self._edge_weights is not None and n_edges > 0,
             "columns": columns_meta,
             "card": self._card_config,
-            "filters": self._filterable if self._filterable else (layout_options or None),
+            "filters": self._filter_options(),
             "search": self._searchable if self._searchable else (label_options or None),
         }
 

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -1049,6 +1049,119 @@ class TestPlotStatic:
 # =============================================================================
 
 
+class TestAddFilter:
+    """Tests for add_filter: filter panel columns without a color layout."""
+
+    def test_registers_column_without_layout(self, viz_with_data):
+        viz, data = viz_with_data
+        viz.add_filter("score", data["continuous"])
+
+        assert "score" in viz._columns
+        assert viz._columns["score"].dtype == "continuous"
+        assert viz._columns["score"].color is None
+        assert viz._layout_keys == []
+        assert [c.name for c in viz.layouts] == []
+
+    def test_added_as_label_by_default(self, viz_with_data):
+        viz, data = viz_with_data
+        viz.add_filter("score", data["continuous"])
+
+        assert viz._columns["score"].role == "filter+label"
+        assert "score" in viz._labels_keys
+
+    def test_add_as_label_false(self, viz_with_data):
+        viz, data = viz_with_data
+        viz.add_filter("score", data["continuous"], add_as_label=False)
+
+        assert viz._columns["score"].role == "filter"
+        assert "score" not in viz._labels_keys
+
+    def test_categorical_filter(self, viz_with_data):
+        viz, data = viz_with_data
+        viz.add_filter("group", data["categorical"], categorical=True)
+
+        assert viz._columns["group"].dtype == "categorical"
+        assert viz._columns["group"].color is None
+
+    def test_continuous_rejects_non_numeric(self, viz_with_data):
+        viz, data = viz_with_data
+        with pytest.raises(ValueError, match="categorical=True"):
+            viz.add_filter("group", data["categorical"])
+
+    def test_rejects_existing_color_layout(self, viz_with_data):
+        viz, data = viz_with_data
+        viz.add_color_layout("score", data["continuous"])
+        with pytest.raises(ValueError, match="already exists as a color layout"):
+            viz.add_filter("score", data["continuous"])
+
+    def test_repeated_call_does_not_duplicate(self, viz_with_data):
+        viz, data = viz_with_data
+        viz.add_filter("score", data["continuous"])
+        viz.add_filter("score", data["continuous"])
+
+        assert viz._filter_keys == ["score"]
+
+    def test_metadata_lists_filter_without_colormap(self, viz_with_data, tmp_path):
+        viz, data = viz_with_data
+        viz.add_filter("score", data["continuous"])
+        viz.add_filter("group", data["categorical"], categorical=True)
+
+        out = viz.write_static(tmp_path / "out")
+        meta = json.loads((out / "metadata.json").read_text())
+
+        assert meta["filters"] == ["score", "group"]
+        assert meta["layoutOptions"] == []
+        # No colors were worked out for these columns.
+        assert meta["colormaps"] == {}
+        assert meta["columns"]["score"]["colormap"] is None
+        assert meta["columns"]["score"]["dtype"] == "float32"
+        assert meta["columns"]["group"]["dtype"] == "uint32"
+        assert sorted(meta["columns"]["group"]["dictionary"]) == ["A", "B", "C"]
+
+    def test_filters_come_before_color_layouts(self, viz_with_data, tmp_path):
+        viz, data = viz_with_data
+        viz.add_color_layout("value", data["continuous"])
+        viz.add_filter("score", data["continuous"])
+
+        out = viz.write_static(tmp_path / "out")
+        meta = json.loads((out / "metadata.json").read_text())
+
+        assert meta["filters"] == ["score", "value"]
+
+    def test_filterable_property_overrides(self, viz_with_data, tmp_path):
+        viz, data = viz_with_data
+        viz.add_color_layout("value", data["continuous"])
+        viz.add_filter("score", data["continuous"])
+        viz.filterable = ["value"]
+
+        out = viz.write_static(tmp_path / "out")
+        meta = json.loads((out / "metadata.json").read_text())
+
+        assert meta["filters"] == ["value"]
+
+    def test_comparison_falls_back_to_filter_columns(self, viz_with_data):
+        # With no color layouts, the neighbour comparison has to take its
+        # numbers from the filter panel instead.
+        viz, data = viz_with_data
+        viz.add_filter("score", data["continuous"])
+
+        html = viz.to_html()
+
+        assert "[...new Set([...filterColumnNames, ...layoutOptions])]" in html
+
+    def test_inline_html_carries_filter_column(self, viz_with_data):
+        viz, data = viz_with_data
+        viz.add_filter("score", data["continuous"])
+
+        html = viz.to_html()
+        match = re.search(r"const metadata = ({.*?});", html, re.DOTALL)
+        assert match is not None
+        meta = json.loads(match.group(1))
+
+        assert meta["filters"] == ["score"]
+        assert "score" in meta["columns"]
+
+
 class TestFilterableProperty:
     """Tests for the filterable property."""
 


### PR DESCRIPTION
Fixes #29.

## The problem

The only way to get a column into the filter panel was `add_color_layout`,
which also picks a colormap for it. If you only wanted to filter on a column,
you paid for colors you were never going to use.

## The fix

```python
viz.add_filter("MW", props["mw"].tolist())
viz.add_filter("Ring Count", props["n_rings"].tolist(), categorical=True)
```

The column is packed exactly the way a color layout is, so the panel behaves
the same: a slider for numbers, one clickable bar per group for categories.
What it skips is the color work, and it stays out of the color selector.

Color layouts can already be filtered on, so `add_filter` columns go into the
panel on top of them rather than instead of them. Setting `filterable` by hand
still replaces the lot:

```python
viz.filterable = ["MW", "LogP"]   # exactly these, nothing else
```

`add_as_label=False` keeps a filter column out of the hover tooltip.

Calling `add_filter` on a name that is already a color layout raises, since
that column can already be filtered on and overwriting it would lose its
colors.

## What changed

- `TmapViz.add_filter`, plus a `filter` / `filter+label` column role.
- The numeric checks in `add_color_layout` moved into a shared helper, so both
  methods reject text in a numeric column the same way.
- The panel itself needed no JavaScript changes. It reads `metadata.filters`
  and fetches whatever that names.
- One template change: the neighbour comparison strip picked its numbers from
  the color layouts alone, so it came up empty on a map built only with
  `add_filter`. It now draws from the filter panel and the color layouts
  together.
- `docs/visualization_guide.md` and `docs/api_reference.md`.

## Tests

12 new tests: the column is registered but is not a layout, no colormap is
produced for it, categorical and numeric packing, `add_as_label`, the error on
a name that is already a layout, panel ordering, `filterable` still winning,
and the comparison strip falling back to the filter columns.
