### PR TITLE
Fix adaptive prefix search in LSH forest

### DIFF
--- a/docs/lshforest_guide.md
+++ b/docs/lshforest_guide.md
@@ -8,7 +8,7 @@ This guide explains how LSH Forest works in TMAP and helps you choose the right 
 
 LSH Forest is an **index structure** for fast approximate nearest neighbor search. It takes MinHash signatures and enables rapid similarity queries.
 
-**The key insight:** Instead of comparing every item to every other item (O(n²)), LSH Forest uses clever hashing to find similar items in O(n log n) time.
+**The key insight:** Instead of comparing every item to every other item (O(n²)), LSH Forest uses sorted MinHash prefixes to find likely neighbors efficiently.
 
 ```txt
 MinHash Signatures
@@ -30,7 +30,7 @@ mh = MinHash(num_perm=128, seed=42)
 signatures = mh.batch_from_binary_array(fingerprints)
 
 # 2. Build the index
-lsh = LSHForest(d=128, l=64)  # d must match num_perm
+lsh = LSHForest(d=128, l=16)  # d must match num_perm
 lsh.batch_add(signatures)
 lsh.index()  # Don't forget this!
 
@@ -42,28 +42,29 @@ knn = lsh.get_knn_graph(k=20, kc=50)
 
 ## How LSH Forest Works (Conceptually)
 
-Think of LSH Forest as organizing items into **buckets** based on their hash values.
+Think of LSH Forest as maintaining several sorted indexes over different parts of each signature.
 
-### The Bucket Analogy
+### Adaptive Prefix Search
 
-1. **Hashing**: Each signature is split into `l` bands. Each band produces a hash value.
-2. **Bucketing**: Items with the same band hash go into the same bucket.
-3. **Querying**: To find neighbors, look in buckets where the query item lands.
+1. **Split**: Each signature is split into `l` consecutive bands.
+2. **Sort**: Each band becomes a prefix tree represented by lexicographically sorted row IDs.
+3. **Query**: Search for complete-band matches first. If there are too few candidates, shorten every tree prefix by one MinHash value and repeat.
+4. **Refine**: Rank the collected candidates by their full MinHash-signature distance.
 
 ```txt
 Signature (128 values)
     ↓
-Split into l=8 bands (16 values each)
+Split into l=16 bands (8 values each)
     ↓
-Band 0: hash → bucket A
-Band 1: hash → bucket B
-Band 2: hash → bucket C
+Tree 0: sort values 0..7
+Tree 1: sort values 8..15
+Tree 2: sort values 16..23
 ...
     ↓
-Query: check all buckets, collect candidates
+Query: try prefix lengths 8, 7, ... 1 until enough candidates exist
 ```
 
-**Why multiple bands?** More bands = more chances to find similar items, even if they don't match perfectly in any single band.
+**Why adaptive prefixes?** A strict eight-value collision is often too rare. Backoff preserves selective matches when they exist but still returns useful candidates for moderately similar data.
 
 ---
 
@@ -82,31 +83,31 @@ lsh = LSHForest(d=128)      # d=128 to match
 
 Controls the **recall vs speed** tradeoff.
 
-| `l` Value | Recall | Speed | Memory | Best For |
-|-----------|--------|-------|--------|----------|
-| 8 | Low | Fastest | Low | Quick exploration |
-| 32 | Medium | Fast | Medium | Small datasets (<10k) |
-| 64 | Good | Good | Good | **Medium datasets (10k-100k)** |
-| 128 | High | Slower | High | Large datasets (>100k) |
+| Configuration | Band width | Tradeoff |
+|---------------|------------|----------|
+| `d=128, l=8` | 16 | Legacy TMAP default; lowest index memory |
+| `d=128, l=16` | 8 | Good compatibility/quality starting point |
+| `d=128, l=32` | 4 | More trees and memory; useful for difficult set data |
+| `d=128, l=64` | 2 | Aggressive, usually unnecessary with prefix backoff |
 
-**Rule of thumb:** Start with `l=64`. Increase if you're missing neighbors.
+**Rule of thumb:** Start with `l=d//8` and tune `kc` first. More trees consume memory linearly and are no longer required merely to avoid empty exact-band buckets.
 
 ```python
 # For a 50k molecule dataset
-lsh = LSHForest(d=128, l=64)
+lsh = LSHForest(d=128, l=16)
 ```
 
 ### `store` - Signature Storage
 
-Controls whether signatures are kept in memory after indexing.
+Controls whether signature-dependent refinement and inspection methods are exposed. Adaptive prefix lookup itself must retain the indexed band values, so `store=False` no longer removes the core signature memory.
 
-| Value | Memory | Capabilities |
-|-------|--------|--------------|
-| `True` (default) | Higher | Full functionality: queries, distances, k-NN graph |
-| `False` | Lower | Only LSH queries (no linear scan, no k-NN graph) |
+| Value | Capabilities |
+|-------|--------------|
+| `True` (default) | Full functionality: queries, distances, k-NN graph |
+| `False` | Prefix queries only; no linear scan, distances, or k-NN graph |
 
 ```python
-# Memory-constrained: only need approximate queries
+# Prefix candidate queries only
 lsh = LSHForest(d=128, store=False)
 
 # Full functionality (recommended)
@@ -347,7 +348,7 @@ knn = lsh.get_knn_graph(k=20, kc=50)
 **What's saved:**
 
 - All signatures
-- Hash band structures
+- Sorted prefix-tree row IDs
 - Configuration (d, l, weighted, store)
 
 ---
@@ -358,7 +359,7 @@ knn = lsh.get_knn_graph(k=20, kc=50)
 
 ```python
 # Build index (expensive)
-lsh = LSHForest(d=128, l=64)
+lsh = LSHForest(d=128, l=16)
 lsh.batch_add(all_signatures)
 lsh.index()
 lsh.save("index.pkl")
@@ -372,7 +373,7 @@ knn = lsh.get_knn_graph(k=20, kc=50)
 
 ```python
 # Initial index
-lsh = LSHForest(d=128, l=64)
+lsh = LSHForest(d=128, l=16)
 lsh.batch_add(initial_signatures)
 lsh.index()
 
@@ -388,7 +389,7 @@ knn = lsh.get_knn_graph(k=20, kc=50)
 
 ```python
 # Build index of known compounds
-lsh = LSHForest(d=128, l=64)
+lsh = LSHForest(d=128, l=16)
 lsh.batch_add(known_signatures)
 lsh.index()
 
@@ -527,14 +528,14 @@ knn2 = lsh.get_knn_graph(k=20, kc=50)
 knn3 = lsh.get_knn_graph(k=30, kc=100)
 ```
 
-### 3. Tune l Based on Dataset Size
+### 3. Tune Candidate Budget Before Adding Trees
 
 ```python
-# Small dataset: lower l is fine
-lsh = LSHForest(d=128, l=32)  # < 10k points
+# Compatibility-oriented starting point
+lsh = LSHForest(d=128, l=16)
 
-# Large dataset: higher l for better recall
-lsh = LSHForest(d=128, l=128)  # > 100k points
+# Search more candidates before increasing index memory
+knn = lsh.get_knn_graph(k=20, kc=100)
 ```
 
 ---
@@ -556,7 +557,7 @@ mh = MinHash(num_perm=128, seed=42)
 signatures = mh.batch_from_binary_array(fps)
 
 # 3. Build LSH Forest
-lsh = LSHForest(d=128, l=64)
+lsh = LSHForest(d=128, l=16)
 lsh.batch_add(signatures)
 lsh.index()
 

--- a/src/tmap/estimator.py
+++ b/src/tmap/estimator.py
@@ -39,11 +39,10 @@ def _resolve_ann_backend(
 def _select_lsh_l(d: int, n_samples: int) -> int:
     """Auto-select number of LSH prefix trees based on d and dataset size.
 
-    The LSH band width (k_band = d // l) controls discrimination:
-    - Short bands (small k_band): high recall but many false positives.
-      At large N, the candidate budget (k*kc) overflows with random matches.
-    - Long bands (large k_band): precise candidates but low recall.
-      At small N, too few collisions to find any neighbors.
+    Queries adaptively shorten each tree prefix until their candidate budget is
+    filled. The full band width (``k_band = d // l``) therefore controls the
+    number of selective prefix depths available, rather than imposing an exact
+    full-band collision requirement.
 
     We use k_band=4 up to ~1M points (tested optimal for 100k molecules),
     then gradually increase for larger datasets where the collision pool

--- a/src/tmap/index/_lsh_numba.py
+++ b/src/tmap/index/_lsh_numba.py
@@ -149,6 +149,7 @@ def linear_scan_batch(
     candidate_counts: NDArray[np.int32],
     k: int,
     exclude_self: bool = True,
+    query_offset: int = 0,
 ) -> tuple[NDArray[np.int32], NDArray[np.float32]]:
     """
     Perform linear scan for multiple queries in parallel.
@@ -164,6 +165,8 @@ def linear_scan_batch(
         k: Number of nearest neighbors to return per query
         exclude_self: If True, candidate with index == query index is
             skipped (for self-kNN).  Set False for external queries.
+        query_offset: Global row offset of ``queries[0]`` for blocked
+            self-kNN construction.
 
     Returns:
         Tuple of:
@@ -187,7 +190,7 @@ def linear_scan_batch(
             cand_idx = candidate_indices[q, i]
             if cand_idx < 0:
                 cand_distances[i] = 2.0  # Invalid candidate
-            elif exclude_self and cand_idx == q:
+            elif exclude_self and cand_idx == q + query_offset:
                 cand_distances[i] = 2.0  # Exclude self
             else:
                 # Compute Jaccard distance
@@ -221,6 +224,7 @@ def linear_scan_batch_weighted(
     candidate_counts: NDArray[np.int32],
     k: int,
     exclude_self: bool = True,
+    query_offset: int = 0,
 ) -> tuple[NDArray[np.int32], NDArray[np.float32]]:
     """
     Perform linear scan for multiple weighted queries in parallel.
@@ -233,6 +237,8 @@ def linear_scan_batch_weighted(
         k: Number of nearest neighbors to return
         exclude_self: If True, candidate with index == query index is
             skipped (for self-kNN).  Set False for external queries.
+        query_offset: Global row offset of ``queries[0]`` for blocked
+            self-kNN construction.
 
     Returns:
         Tuple of (indices, distances) arrays
@@ -251,7 +257,7 @@ def linear_scan_batch_weighted(
         cand_distances = np.empty(n_cand, dtype=np.float32)
         for i in range(n_cand):
             cand_idx = candidate_indices[q, i]
-            if cand_idx < 0 or (exclude_self and cand_idx == q):
+            if cand_idx < 0 or (exclude_self and cand_idx == q + query_offset):
                 cand_distances[i] = 2.0
             else:
                 matches = 0
@@ -278,282 +284,246 @@ def linear_scan_batch_weighted(
     return result_indices, result_distances
 
 
-@numba.njit(parallel=True, cache=True)
-def compute_hash_bands(
+@numba.njit(cache=True, inline="always")
+def _compare_prefix(
     signatures: NDArray[np.uint64],
-    l: int,
-    k: int,
-) -> NDArray[np.uint64]:
-    """
-    Compute L hash bands for all N signatures in parallel.
-
-    Each band hashes k consecutive values from the signature.
-    This is the core LSH operation - similar signatures will have
-    matching bands with high probability.
-
-    Args:
-        signatures: (N, d) uint64 array of MinHash signatures
-        l: Number of bands (prefix trees)
-        k: Band width (d // l)
-
-    Returns:
-        hash_bands: (N, l) uint64 array of hash values per band
-    """
-    n = signatures.shape[0]
-    hash_bands = np.empty((n, l), dtype=np.uint64)
-
-    for i in prange(n):
-        for band in range(l):
-            start = band * k
-            end = start + k
-            # Inline hash computation for speed
-            GOLDEN = np.uint64(0x9E3779B97F4A7C15)
-            h = np.uint64(0)
-            for j in range(start, end):
-                v = signatures[i, j]
-                v ^= v >> np.uint64(33)
-                v *= GOLDEN
-                v ^= v >> np.uint64(33)
-                h ^= v + GOLDEN + (h << np.uint64(6)) + (h >> np.uint64(2))
-            hash_bands[i, band] = h
-
-    return hash_bands
+    row: int,
+    query: NDArray[np.uint64],
+    start: int,
+    prefix_length: int,
+) -> int:
+    """Compare one stored band prefix with a query prefix lexicographically."""
+    for offset in range(prefix_length):
+        stored = signatures[row, start + offset]
+        wanted = query[start + offset]
+        if stored < wanted:
+            return -1
+        if stored > wanted:
+            return 1
+    return 0
 
 
-@numba.njit(parallel=True, cache=True)
-def compute_hash_bands_weighted(
+@numba.njit(cache=True, inline="always")
+def _compare_prefix_weighted(
     signatures: NDArray[np.uint64],
-    l: int,
-    k: int,
-) -> NDArray[np.uint64]:
-    """
-    Compute L hash bands for weighted MinHash signatures.
-
-    For weighted MinHash, only uses the first column (k values) for LSH looku
-
-    Args:
-        signatures: (N, d, 2) uint64 array of weighted MinHash signatures
-        l: Number of bands
-        k: Band width
-
-    Returns:
-        hash_bands: (N, l) uint64 array of hash values
-    """
-    n = signatures.shape[0]
-    hash_bands = np.empty((n, l), dtype=np.uint64)
-
-    for i in prange(n):
-        for band in range(l):
-            start = band * k
-            end = start + k
-            GOLDEN = np.uint64(0x9E3779B97F4A7C15)
-            h = np.uint64(0)
-            for j in range(start, end):
-                # Only use first column for weighted MinHash LSH
-                v = signatures[i, j, 0]
-                v ^= v >> np.uint64(33)
-                v *= GOLDEN
-                v ^= v >> np.uint64(33)
-                h ^= v + GOLDEN + (h << np.uint64(6)) + (h >> np.uint64(2))
-            hash_bands[i, band] = h
-
-    return hash_bands
+    row: int,
+    query: NDArray[np.uint64],
+    start: int,
+    prefix_length: int,
+) -> int:
+    """Compare weighted MinHash prefixes, including both values per permutation."""
+    for offset in range(prefix_length):
+        for component in range(2):
+            stored = signatures[row, start + offset, component]
+            wanted = query[start + offset, component]
+            if stored < wanted:
+                return -1
+            if stored > wanted:
+                return 1
+    return 0
 
 
-@numba.njit(cache=True)
-def _binary_search_left(arr: NDArray[np.uint64], value: np.uint64) -> int:
-    """Binary search for leftmost position where arr[i] >= value."""
-    lo, hi = 0, len(arr)
-    while lo < hi:
-        mid = (lo + hi) // 2
-        if arr[mid] < value:
-            lo = mid + 1
-        else:
-            hi = mid
-    return lo
-
-
-@numba.njit(cache=True)
-def _binary_search_right(arr: NDArray[np.uint64], value: np.uint64) -> int:
-    """Binary search for leftmost position where arr[i] > value."""
-    lo, hi = 0, len(arr)
-    while lo < hi:
-        mid = (lo + hi) // 2
-        if arr[mid] <= value:
-            lo = mid + 1
-        else:
-            hi = mid
-    return lo
-
-
-@numba.njit(cache=True)
-def query_single_band(
-    query_hash: np.uint64,
-    sorted_hashes: NDArray[np.uint64],
+@numba.njit(cache=True, inline="always")
+def _prefix_range(
+    signatures: NDArray[np.uint64],
     sorted_indices: NDArray[np.int32],
-) -> NDArray[np.int32]:
-    """
-    Query a single band's hash table using binary search.
+    query: NDArray[np.uint64],
+    start: int,
+    prefix_length: int,
+) -> tuple[int, int]:
+    """Return the half-open range of rows equal to an unweighted prefix."""
+    lo = 0
+    hi = len(sorted_indices)
+    while lo < hi:
+        mid = (lo + hi) // 2
+        comparison = _compare_prefix(signatures, sorted_indices[mid], query, start, prefix_length)
+        if comparison < 0:
+            lo = mid + 1
+        else:
+            hi = mid
+    left = lo
 
-    Args:
-        query_hash: Hash value of the query's band
-        sorted_hashes: Sorted array of hash values for this band
-        sorted_indices: Corresponding signature indices (sorted by hash)
-
-    Returns:
-        Array of matching signature indices (may be empty)
-    """
-    if len(sorted_hashes) == 0:
-        return np.empty(0, dtype=np.int32)
-
-    # Find range of matching hashes
-    left = _binary_search_left(sorted_hashes, query_hash)
-    right = _binary_search_right(sorted_hashes, query_hash)
-
-    if left >= right:
-        return np.empty(0, dtype=np.int32)
-
-    return sorted_indices[left:right].copy()
+    hi = len(sorted_indices)
+    while lo < hi:
+        mid = (lo + hi) // 2
+        comparison = _compare_prefix(signatures, sorted_indices[mid], query, start, prefix_length)
+        if comparison <= 0:
+            lo = mid + 1
+        else:
+            hi = mid
+    return left, lo
 
 
-@numba.njit(cache=True)
-def query_lsh_forest_single(
-    query_bands: NDArray[np.uint64],
-    sorted_hashes_list: tuple,
-    sorted_indices_list: tuple,
-    max_results: int,
-) -> NDArray[np.int32]:
-    """
-    Query LSH forest for a single signature.
-
-    Searches all bands and collects unique candidates up to max_results.
-    Uses exact band-hash matching — candidate recall depends on band width
-    (k = d/l) and data similarity.
-
-    Args:
-        query_bands: (l,) array of hash values for query
-        sorted_hashes_list: Tuple of L sorted hash arrays
-        sorted_indices_list: Tuple of L sorted index arrays
-        max_results: Maximum number of candidates to return
-
-    Returns:
-        Array of candidate indices (unique, up to max_results)
-    """
-    l = len(query_bands)
-
-    # Collect candidates from all bands
-    # Use a fixed-size array and track seen indices
-    candidates = np.empty(max_results * l, dtype=np.int32)
-    n_candidates = 0
-
-    # Simple seen tracking - for small result sets this is fast enough
-    seen = np.zeros(max_results * l * 2, dtype=np.int32)
-    seen_count = 0
-
-    for band in range(l):
-        matches = query_single_band(
-            query_bands[band],
-            sorted_hashes_list[band],
-            sorted_indices_list[band],
+@numba.njit(cache=True, inline="always")
+def _prefix_range_weighted(
+    signatures: NDArray[np.uint64],
+    sorted_indices: NDArray[np.int32],
+    query: NDArray[np.uint64],
+    start: int,
+    prefix_length: int,
+) -> tuple[int, int]:
+    """Return the half-open range of rows equal to a weighted prefix."""
+    lo = 0
+    hi = len(sorted_indices)
+    while lo < hi:
+        mid = (lo + hi) // 2
+        comparison = _compare_prefix_weighted(
+            signatures, sorted_indices[mid], query, start, prefix_length
         )
+        if comparison < 0:
+            lo = mid + 1
+        else:
+            hi = mid
+    left = lo
 
-        for j in range(len(matches)):
-            idx = matches[j]
-            # Check if already seen (linear search - ok for small sets)
-            is_seen = False
-            for s in range(seen_count):
-                if seen[s] == idx:
-                    is_seen = True
-                    break
+    hi = len(sorted_indices)
+    while lo < hi:
+        mid = (lo + hi) // 2
+        comparison = _compare_prefix_weighted(
+            signatures, sorted_indices[mid], query, start, prefix_length
+        )
+        if comparison <= 0:
+            lo = mid + 1
+        else:
+            hi = mid
+    return left, lo
 
-            if not is_seen:
-                if n_candidates < max_results:
-                    candidates[n_candidates] = idx
-                    n_candidates += 1
-                if seen_count < len(seen):
-                    seen[seen_count] = idx
-                    seen_count += 1
 
-                if n_candidates >= max_results:
-                    return candidates[:n_candidates]
+@numba.njit(cache=True, inline="always")
+def _seen_or_insert(seen: NDArray[np.int32], value: int) -> bool:
+    """Insert into a small open-addressed set; return whether it was present."""
+    mask = len(seen) - 1
+    slot = (value * 2654435761) & mask
+    while True:
+        current = seen[slot]
+        if current == value:
+            return True
+        if current == -1:
+            seen[slot] = value
+            return False
+        slot = (slot + 1) & mask
 
-    return candidates[:n_candidates]
+
+@numba.njit(cache=True, inline="always")
+def _seen_table_size(max_results: int) -> int:
+    """Choose a power-of-two hash table with a load factor at most 0.5."""
+    size = 2
+    target = max_results * 2
+    while size < target:
+        size *= 2
+    return size
 
 
 @numba.njit(parallel=True, cache=True)
 def query_lsh_forest_batch(
-    query_bands: NDArray[np.uint64],
-    sorted_hashes_flat: NDArray[np.uint64],
+    queries: NDArray[np.uint64],
+    signatures: NDArray[np.uint64],
     sorted_indices_flat: NDArray[np.int32],
     band_offsets: NDArray[np.int64],
+    band_width: int,
     max_results: int,
 ) -> tuple[NDArray[np.int32], NDArray[np.int32]]:
+    """Retrieve candidates using adaptive LSH-Forest prefix backoff.
+
+    Every tree owns a disjoint band of ``band_width`` MinHash values. Rows are
+    sorted lexicographically by their complete band. Queries first retrieve
+    exact full-band matches, then shorten the prefix one value at a time until
+    ``max_results`` unique candidates have been collected or the one-value
+    prefixes are exhausted. This mirrors the original TMAP C++ LSH Forest.
     """
-    Query LSH forest for multiple signatures in parallel.
+    n_queries = queries.shape[0]
+    n_trees = len(band_offsets) - 1
+    n_indexed = signatures.shape[0]
+    result_limit = min(max_results, n_indexed)
 
-    Uses flattened arrays for Numba compatibility.
-
-    Args:
-        query_bands: (n_queries, l) array of hash values
-        sorted_hashes_flat: Flattened sorted hashes for all bands
-        sorted_indices_flat: Flattened sorted indices for all bands
-        band_offsets: (l+1,) offsets into flat arrays for each band
-        max_results: Maximum candidates per query
-
-    Returns:
-        candidates: (n_queries, max_results) padded with -1
-        counts: (n_queries,) number of valid candidates per query
-    """
-    n_queries = query_bands.shape[0]
-    l = query_bands.shape[1]
-
-    candidates = np.full((n_queries, max_results), -1, dtype=np.int32)
+    candidates = np.full((n_queries, result_limit), -1, dtype=np.int32)
     counts = np.zeros(n_queries, dtype=np.int32)
+    table_size = _seen_table_size(result_limit)
 
     for q in prange(n_queries):
-        # Track seen indices for this query
-        seen = np.zeros(max_results * 2, dtype=np.int32)
-        seen_count = 0
-        n_cand = 0
+        seen = np.full(table_size, -1, dtype=np.int32)
+        n_candidates = 0
 
-        for band in range(l):
-            # Get this band's slice of the flat arrays
-            start = band_offsets[band]
-            end = band_offsets[band + 1]
-            band_hashes = sorted_hashes_flat[start:end]
-            band_indices = sorted_indices_flat[start:end]
+        for prefix_length in range(band_width, 0, -1):
+            for tree in range(n_trees):
+                offset = band_offsets[tree]
+                end = band_offsets[tree + 1]
+                sorted_indices = sorted_indices_flat[offset:end]
+                start = tree * band_width
+                left, right = _prefix_range(
+                    signatures,
+                    sorted_indices,
+                    queries[q],
+                    start,
+                    prefix_length,
+                )
 
-            query_hash = query_bands[q, band]
-
-            # Binary search for matching range
-            left = _binary_search_left(band_hashes, query_hash)
-            right = _binary_search_right(band_hashes, query_hash)
-
-            # Add unique matches
-            for i in range(left, right):
-                idx = band_indices[i]
-
-                # Check if seen
-                is_seen = False
-                for s in range(seen_count):
-                    if seen[s] == idx:
-                        is_seen = True
-                        break
-
-                if not is_seen:
-                    if n_cand < max_results:
-                        candidates[q, n_cand] = idx
-                        n_cand += 1
-                    if seen_count < len(seen):
-                        seen[seen_count] = idx
-                        seen_count += 1
-
-                    if n_cand >= max_results:
-                        break
-
-            if n_cand >= max_results:
+                for position in range(left, right):
+                    candidate = int(sorted_indices[position])
+                    if not _seen_or_insert(seen, candidate):
+                        candidates[q, n_candidates] = candidate
+                        n_candidates += 1
+                        if n_candidates == result_limit:
+                            break
+                if n_candidates == result_limit:
+                    break
+            if n_candidates == result_limit:
                 break
 
-        counts[q] = n_cand
+        counts[q] = n_candidates
+
+    return candidates, counts
+
+
+@numba.njit(parallel=True, cache=True)
+def query_lsh_forest_batch_weighted(
+    queries: NDArray[np.uint64],
+    signatures: NDArray[np.uint64],
+    sorted_indices_flat: NDArray[np.int32],
+    band_offsets: NDArray[np.int64],
+    band_width: int,
+    max_results: int,
+) -> tuple[NDArray[np.int32], NDArray[np.int32]]:
+    """Weighted adaptive-prefix retrieval using both values per permutation."""
+    n_queries = queries.shape[0]
+    n_trees = len(band_offsets) - 1
+    n_indexed = signatures.shape[0]
+    result_limit = min(max_results, n_indexed)
+
+    candidates = np.full((n_queries, result_limit), -1, dtype=np.int32)
+    counts = np.zeros(n_queries, dtype=np.int32)
+    table_size = _seen_table_size(result_limit)
+
+    for q in prange(n_queries):
+        seen = np.full(table_size, -1, dtype=np.int32)
+        n_candidates = 0
+
+        for prefix_length in range(band_width, 0, -1):
+            for tree in range(n_trees):
+                offset = band_offsets[tree]
+                end = band_offsets[tree + 1]
+                sorted_indices = sorted_indices_flat[offset:end]
+                start = tree * band_width
+                left, right = _prefix_range_weighted(
+                    signatures,
+                    sorted_indices,
+                    queries[q],
+                    start,
+                    prefix_length,
+                )
+
+                for position in range(left, right):
+                    candidate = int(sorted_indices[position])
+                    if not _seen_or_insert(seen, candidate):
+                        candidates[q, n_candidates] = candidate
+                        n_candidates += 1
+                        if n_candidates == result_limit:
+                            break
+                if n_candidates == result_limit:
+                    break
+            if n_candidates == result_limit:
+                break
+
+        counts[q] = n_candidates
 
     return candidates, counts

--- a/src/tmap/index/lsh_forest.py
+++ b/src/tmap/index/lsh_forest.py
@@ -2,8 +2,8 @@
 LSH Forest implementation for approximate nearest neighbor search.
 
 This module provides a custom Numba-accelerated implementation:
-- Numba JIT for hash band computation (parallel, 50-100x faster than datasketch)
-- Sorted arrays with binary search for O(log n) lookups
+- Lexicographically sorted prefix trees with adaptive prefix backoff
+- Numba JIT candidate retrieval and distance computation
 - Numba JIT for distance computation and linear scan
 
 The LSH Forest is optimized for Jaccard similarity on MinHash signatures,
@@ -11,7 +11,9 @@ The LSH Forest is optimized for Jaccard similarity on MinHash signatures,
 
 from __future__ import annotations
 
+import os
 import pickle
+from concurrent.futures import ThreadPoolExecutor
 from typing import cast
 
 import numpy as np
@@ -19,18 +21,19 @@ from numpy.typing import NDArray
 
 from ._lsh_numba import (
     compute_distances_to_candidates,
-    compute_hash_bands,
-    compute_hash_bands_weighted,
     compute_weighted_distances_to_candidates,
     jaccard_distance,
     linear_scan_batch,
     linear_scan_batch_weighted,
     query_lsh_forest_batch,
+    query_lsh_forest_batch_weighted,
     weighted_jaccard_distance,
 )
 from .types import KNNGraph
 
 __all__ = ["LSHForest"]
+
+_CANDIDATE_BUFFER_BYTES = 256 * 1024 * 1024
 
 
 class LSHForest:
@@ -39,10 +42,11 @@ class LSHForest:
 
     Args:
         d: Dimensionality of MinHash vectors (number of permutations). Default: 128
-        l: Number of prefix trees (bands). Default: d // 2. Lower values increase
-            band width (k = d // l), which reduces candidate recall for low-similarity
-            data. The safe range depends on dataset similarity — see ISS-018.
-        store: Store signatures for linear scan and distance queries. Default: True
+        l: Number of prefix trees. Each tree owns ``d // l`` consecutive
+            signature values. Default: 8, matching the original TMAP API.
+        store: Expose signatures for linear scan and distance methods. The
+            prefix index itself always retains the values needed for queries.
+            Default: True.
         weighted: Whether using weighted MinHash signatures. Default: False
 
     Example:
@@ -53,7 +57,7 @@ class LSHForest:
         >>> mh = MinHash(num_perm=128)
         >>> sigs = mh.batch_from_binary_array(fingerprints)
         >>>
-        >>> # Build LSH Forest (default l=d//2 for good recall)
+        >>> # Build LSH Forest
         >>> lsh = LSHForest(d=128)
         >>> lsh.batch_add(sigs)
         >>> lsh.index()
@@ -73,7 +77,7 @@ class LSHForest:
             raise ValueError("d must be positive")
 
         if l is None:
-            l = d // 2
+            l = min(8, d)
 
         if l <= 0:
             raise ValueError("l must be positive")
@@ -86,14 +90,12 @@ class LSHForest:
         self._store = store
         self._weighted = weighted
 
-        # Signature storage for linear scan and distance queries
-        # Collected in list during adds, converted to contiguous array in index()
+        # Pending signatures are collected in batches and made contiguous by index().
         self._signatures_list: list[NDArray[np.uint64]] = []
+        self._index_signatures: NDArray[np.uint64] | None = None
         self._signatures: NDArray[np.uint64] | None = None
 
-        # LSH index structures (built in index())
-        self._hash_bands: NDArray[np.uint64] | None = None
-        self._sorted_hashes_flat: NDArray[np.uint64] | None = None
+        # Each tree stores row IDs in lexicographic order of its full band.
         self._sorted_indices_flat: NDArray[np.int32] | None = None
         self._band_offsets: NDArray[np.int64] | None = None
 
@@ -157,6 +159,21 @@ class LSHForest:
         else:
             return cast(float, jaccard_distance(sig_a, sig_b))
 
+    def _get_index_signatures(self) -> NDArray[np.uint64] | None:
+        """Return index data, including compatibility with older object pickles."""
+        signatures = getattr(self, "_index_signatures", None)
+        if signatures is None:
+            signatures = self._signatures
+            self._index_signatures = signatures
+        return signatures
+
+    @staticmethod
+    def _validate_query_parameters(k: int, kc: int | None = None) -> None:
+        if k <= 0:
+            raise ValueError(f"k must be positive, got {k}")
+        if kc is not None and kc <= 0:
+            raise ValueError(f"kc must be positive, got {kc}")
+
     # Add methods
 
     def add(self, signature: NDArray[np.uint64]) -> None:
@@ -171,9 +188,8 @@ class LSHForest:
         """
         self._validate_signature_shape(signature)
 
-        # Store as 2D/3D batch of size 1 so index() can use np.concatenate
-        if self._store:
-            self._signatures_list.append(signature[np.newaxis].copy())
+        # Prefix queries require the raw band values even when store=False.
+        self._signatures_list.append(signature[np.newaxis].copy())
 
         self._needs_reindex = True
 
@@ -189,10 +205,8 @@ class LSHForest:
         """
         self._validate_signature_shape(signatures, batch=True)
 
-        if self._store:
-            # Store whole batch as one contiguous array (not individual rows).
-            # This avoids N separate Python objects and cuts memory by ~50%.
-            self._signatures_list.append(signatures.copy())
+        # Store a whole batch rather than N individual Python objects.
+        self._signatures_list.append(signatures.copy())
 
         self._needs_reindex = True
 
@@ -204,53 +218,58 @@ class LSHForest:
 
         Must be called after adding signatures with add() or batch_add().
         """
+        previous = self._get_index_signatures()
         if not self._signatures_list:
-            # Nothing to index
-            self._n_indexed = 0
-            self._is_indexed = True
-            self._needs_reindex = False
+            if previous is None:
+                self._n_indexed = 0
+                self._is_indexed = True
+                self._needs_reindex = False
             return
 
         # Convert list to contiguous array for efficient Numba access.
         # Include previously indexed signatures if this is a re-index.
         all_parts = self._signatures_list
-        if self._signatures is not None and len(self._signatures) > 0:
-            all_parts = [self._signatures] + all_parts
+        if previous is not None and len(previous) > 0:
+            all_parts = [previous] + all_parts
 
         if len(all_parts) == 1:
-            self._signatures = all_parts[0]
+            index_signatures = np.ascontiguousarray(all_parts[0])
         else:
-            self._signatures = np.concatenate(all_parts)
+            index_signatures = np.concatenate(all_parts)
         self._signatures_list = []  # free intermediate copies
-        n = self._signatures.shape[0]
+        n = index_signatures.shape[0]
 
-        # Compute hash bands for all signatures
-        if self._weighted:
-            self._hash_bands = compute_hash_bands_weighted(self._signatures, self._l, self._k)
+        def sort_tree(tree: int) -> tuple[int, NDArray[np.int32]]:
+            start = tree * self._k
+            end = start + self._k
+            if self._weighted:
+                band = index_signatures[:, start:end, :].reshape(n, self._k * 2)
+            else:
+                band = index_signatures[:, start:end]
+            # np.lexsort uses its final key as the primary key, hence reverse
+            # the columns so the first value in a band is compared first.
+            keys = tuple(band[:, column] for column in range(band.shape[1] - 1, -1, -1))
+            order = np.lexsort(keys).astype(np.int32, copy=False)
+            return tree, order
+
+        sorted_indices = np.empty((self._l, n), dtype=np.int32)
+        max_workers = min(self._l, os.cpu_count() or 1) if n >= 4096 else 1
+        if max_workers == 1:
+            sorted_trees = map(sort_tree, range(self._l))
+            for tree, order in sorted_trees:
+                sorted_indices[tree] = order
         else:
-            self._hash_bands = compute_hash_bands(self._signatures, self._l, self._k)
+            # NumPy releases the GIL while lexsorting. Trees are independent,
+            # so building them concurrently closes the gap to the OpenMP C++
+            # reference without changing their deterministic order.
+            with ThreadPoolExecutor(max_workers=max_workers) as executor:
+                for tree, order in executor.map(sort_tree, range(self._l)):
+                    sorted_indices[tree] = order
 
-        # Build sorted hash tables for each band
-        # flatten all bands into single arrays
-        sorted_hashes_list = []
-        sorted_indices_list = []
-        band_sizes = []
-
-        for band in range(self._l):
-            band_hashes = self._hash_bands[:, band]
-            # Sort by hash value
-            sort_order = np.argsort(band_hashes)
-            sorted_hashes_list.append(band_hashes[sort_order])
-            sorted_indices_list.append(sort_order.astype(np.int32))
-            band_sizes.append(n)
-
-        # Flatten into contiguous arrays
-        self._sorted_hashes_flat = np.concatenate(sorted_hashes_list)
-        self._sorted_indices_flat = np.concatenate(sorted_indices_list)
-
-        # Compute offsets
-        self._band_offsets = np.zeros(self._l + 1, dtype=np.int64)
-        self._band_offsets[1:] = np.cumsum(band_sizes)
+        self._index_signatures = index_signatures
+        self._signatures = index_signatures if self._store else None
+        self._sorted_indices_flat = sorted_indices.reshape(-1)
+        self._band_offsets = np.arange(self._l + 1, dtype=np.int64) * n
 
         self._n_indexed = n
         self._is_indexed = True
@@ -274,30 +293,27 @@ class LSHForest:
         """
         if not self._is_indexed:
             raise RuntimeError("Must call index() before querying")
+        self._validate_query_parameters(k)
         if self._n_indexed == 0:
             return np.array([], dtype=np.int32)
 
         self._validate_signature_shape(signature)
-
-        # Compute hash bands for query
-        if self._weighted:
-            query_bands = compute_hash_bands_weighted(signature[np.newaxis, :, :], self._l, self._k)
-        else:
-            query_bands = compute_hash_bands(signature[np.newaxis, :], self._l, self._k)
-
+        index_signatures = self._get_index_signatures()
         if (
-            self._sorted_hashes_flat is None
+            index_signatures is None
             or self._sorted_indices_flat is None
             or self._band_offsets is None
         ):
             raise RuntimeError("Index structures not initialized")
 
-        # Query using Numba batch function (single query)
-        candidates, counts = query_lsh_forest_batch(
-            query_bands,
-            self._sorted_hashes_flat,
+        query_batch = signature[np.newaxis]
+        query_fn = query_lsh_forest_batch_weighted if self._weighted else query_lsh_forest_batch
+        candidates, counts = query_fn(
+            query_batch,
+            index_signatures,
             self._sorted_indices_flat,
             self._band_offsets,
+            self._k,
             k,
         )
 
@@ -353,6 +369,7 @@ class LSHForest:
             raise ValueError("linear_scan requires store=True")
         if self._signatures is None:
             raise RuntimeError("Must call index() before linear scan")
+        self._validate_query_parameters(k)
 
         self._validate_signature_shape(signature)
 
@@ -463,7 +480,7 @@ class LSHForest:
         """
         Construct the k-nearest neighbor graph of all indexed signatures.
 
-        This is the primary output method becuase it produces input for OGDF layout
+        This is the primary output method because it produces input for OGDF layout
         and MST construction APIs.
 
         Args:
@@ -477,43 +494,46 @@ class LSHForest:
             raise ValueError("get_knn_graph requires store=True")
         if self._signatures is None or self._n_indexed == 0:
             raise RuntimeError("Must add signatures and call index() first")
+        self._validate_query_parameters(k, kc)
 
-        max_candidates = k * kc
-
+        max_candidates = min(k * kc, self._n_indexed)
+        index_signatures = self._get_index_signatures()
         if (
-            self._hash_bands is None
-            or self._sorted_hashes_flat is None
+            index_signatures is None
             or self._sorted_indices_flat is None
             or self._band_offsets is None
         ):
             raise RuntimeError("Index structures not initialized")
 
-        # Batch query all signatures using Numba-parallel
-        all_candidates, candidate_counts = query_lsh_forest_batch(
-            self._hash_bands,
-            self._sorted_hashes_flat,
-            self._sorted_indices_flat,
-            self._band_offsets,
-            max_candidates,
-        )
+        indices = np.full((self._n_indexed, k), -1, dtype=np.int32)
+        distances = np.full((self._n_indexed, k), np.float32(2.0), dtype=np.float32)
+        bytes_per_query = max(max_candidates * np.dtype(np.int32).itemsize, 1)
+        batch_size = max(1, min(self._n_indexed, _CANDIDATE_BUFFER_BYTES // bytes_per_query))
+        query_fn = query_lsh_forest_batch_weighted if self._weighted else query_lsh_forest_batch
+        scan_fn = linear_scan_batch_weighted if self._weighted else linear_scan_batch
 
-        # Numba-accelerated linear scan
-        if self._weighted:
-            indices, distances = linear_scan_batch_weighted(
-                self._signatures,
-                self._signatures,
-                all_candidates,
-                candidate_counts,
-                k,
+        for start in range(0, self._n_indexed, batch_size):
+            end = min(start + batch_size, self._n_indexed)
+            queries = self._signatures[start:end]
+            candidates, counts = query_fn(
+                queries,
+                index_signatures,
+                self._sorted_indices_flat,
+                self._band_offsets,
+                self._k,
+                max_candidates,
             )
-        else:
-            indices, distances = linear_scan_batch(
+            batch_indices, batch_distances = scan_fn(
+                queries,
                 self._signatures,
-                self._signatures,
-                all_candidates,
-                candidate_counts,
+                candidates,
+                counts,
                 k,
+                True,
+                start,
             )
+            indices[start:end] = batch_indices
+            distances[start:end] = batch_distances
 
         return KNNGraph(indices=indices, distances=distances)
 
@@ -526,7 +546,7 @@ class LSHForest:
         """Query k-nearest stored neighbors for a batch of *external* signatures.
 
         Uses the same Numba-parallel pipeline as :meth:`get_knn_graph`
-        (hash-band retrieval -> linear scan) but does **not** exclude
+        (adaptive-prefix retrieval -> linear scan) but does **not** exclude
         self-matches, since the query signatures are not part of the index.
 
         Parameters
@@ -550,27 +570,24 @@ class LSHForest:
             raise ValueError("query_external_batch requires store=True")
         if self._signatures is None or self._n_indexed == 0:
             raise RuntimeError("Must add signatures and call index() first")
+        self._validate_query_parameters(k, kc)
+        self._validate_signature_shape(signatures, batch=True)
+        index_signatures = self._get_index_signatures()
         if (
-            self._sorted_hashes_flat is None
+            index_signatures is None
             or self._sorted_indices_flat is None
             or self._band_offsets is None
         ):
             raise RuntimeError("Index structures not initialized")
 
-        max_candidates = k * kc
-
-        # Compute hash bands for the external signatures
-        if self._weighted:
-            query_bands = compute_hash_bands_weighted(signatures, self._l, self._k)
-        else:
-            query_bands = compute_hash_bands(signatures, self._l, self._k)
-
-        # Batch LSH candidate retrieval (Numba-parallel)
-        all_candidates, candidate_counts = query_lsh_forest_batch(
-            query_bands,
-            self._sorted_hashes_flat,
+        max_candidates = min(k * kc, self._n_indexed)
+        query_fn = query_lsh_forest_batch_weighted if self._weighted else query_lsh_forest_batch
+        all_candidates, candidate_counts = query_fn(
+            signatures,
+            index_signatures,
             self._sorted_indices_flat,
             self._band_offsets,
+            self._k,
             max_candidates,
         )
 
@@ -583,6 +600,7 @@ class LSHForest:
                 candidate_counts,
                 k,
                 False,
+                0,
             )
         else:
             indices, distances = linear_scan_batch(
@@ -592,6 +610,7 @@ class LSHForest:
                 candidate_counts,
                 k,
                 False,
+                0,
             )
 
         # Replace sentinel 2.0 distances with inf for consistency
@@ -720,19 +739,20 @@ class LSHForest:
             path: File path for serialization
         """
         state = {
+            "format_version": 2,
             "d": self._d,
             "l": self._l,
             "k": self._k,
             "store": self._store,
             "weighted": self._weighted,
+            "index_signatures": self._get_index_signatures(),
             "signatures": self._signatures,
             "signatures_list": self._signatures_list,
-            "hash_bands": self._hash_bands,
-            "sorted_hashes_flat": self._sorted_hashes_flat,
             "sorted_indices_flat": self._sorted_indices_flat,
             "band_offsets": self._band_offsets,
             "n_indexed": self._n_indexed,
             "is_indexed": self._is_indexed,
+            "needs_reindex": self._needs_reindex,
         }
         with open(path, "wb") as f:
             pickle.dump(state, f)
@@ -758,24 +778,32 @@ class LSHForest:
             weighted=state["weighted"],
         )
         instance._k = state["k"]
-        instance._signatures = state["signatures"]
-        instance._signatures_list = state["signatures_list"]
-        instance._hash_bands = state["hash_bands"]
-        instance._sorted_hashes_flat = state["sorted_hashes_flat"]
-        instance._sorted_indices_flat = state["sorted_indices_flat"]
-        instance._band_offsets = state["band_offsets"]
-        instance._n_indexed = state["n_indexed"]
-        instance._is_indexed = state["is_indexed"]
-        instance._needs_reindex = False
+        if state.get("format_version", 1) >= 2:
+            instance._index_signatures = state["index_signatures"]
+            instance._signatures = state["signatures"]
+            instance._signatures_list = state["signatures_list"]
+            instance._sorted_indices_flat = state["sorted_indices_flat"]
+            instance._band_offsets = state["band_offsets"]
+            instance._n_indexed = state["n_indexed"]
+            instance._is_indexed = state["is_indexed"]
+            instance._needs_reindex = state.get("needs_reindex", False)
+        else:
+            # Version 1 stored exact-band hash tables. Rebuild them as adaptive
+            # prefix trees rather than silently retaining the defective index.
+            parts: list[NDArray[np.uint64]] = []
+            if state.get("signatures") is not None:
+                parts.append(state["signatures"])
+            parts.extend(state.get("signatures_list", []))
+            instance._signatures_list = parts
+            instance.index()
 
         return instance
 
     def clear(self) -> None:
         """Clear all added data and computed indices."""
         self._signatures_list = []
+        self._index_signatures = None
         self._signatures = None
-        self._hash_bands = None
-        self._sorted_hashes_flat = None
         self._sorted_indices_flat = None
         self._band_offsets = None
         self._n_indexed = 0

--- a/tests/test_lsh_forest.py
+++ b/tests/test_lsh_forest.py
@@ -11,6 +11,7 @@ Tests cover:
 - Weighted MinHash support
 """
 
+import pickle
 import tempfile
 from pathlib import Path
 
@@ -68,7 +69,7 @@ class TestLSHForestInit:
         """Test default parameter values."""
         lsh = LSHForest()
         assert lsh.d == 128
-        assert lsh.l == 64  # default: d // 2 = 128 // 2
+        assert lsh.l == 8  # matches the original TMAP default
         assert lsh.size == 0
         assert not lsh.is_clean
 
@@ -195,6 +196,73 @@ class TestLSHForestIndex:
 
 class TestLSHForestQuery:
     """Tests for query methods."""
+
+    def test_query_adaptively_shortens_tree_prefixes(self):
+        """Candidates need not collide on a complete fixed-width band."""
+        query = np.array([10, 11, 12, 13, 20, 21, 22, 23], dtype=np.uint64)
+        signatures = np.array(
+            [
+                query,
+                [10, 11, 12, 99, 90, 91, 92, 93],  # tree 0, prefix length 3
+                [80, 81, 82, 83, 20, 21, 98, 99],  # tree 1, prefix length 2
+                [10, 70, 71, 72, 60, 61, 62, 63],  # tree 0, prefix length 1
+                [50, 51, 52, 53, 40, 41, 42, 43],  # no prefix collision
+            ],
+            dtype=np.uint64,
+        )
+        forest = LSHForest(d=8, l=2)
+        forest.batch_add(signatures)
+        forest.index()
+
+        candidates = forest.query(query, k=4)
+
+        assert candidates.tolist() == [0, 1, 2, 3]
+
+    def test_query_matches_adaptive_prefix_reference(self):
+        """Numba retrieval matches a small, direct implementation of C++ semantics."""
+        rng = np.random.default_rng(7)
+        signatures = rng.integers(0, 8, size=(60, 16), dtype=np.uint64)
+        forest = LSHForest(d=16, l=4)
+        forest.batch_add(signatures)
+        forest.index()
+
+        tree_orders = []
+        for tree in range(forest.l):
+            start = tree * forest._k
+            end = start + forest._k
+            tree_orders.append(
+                sorted(
+                    range(len(signatures)),
+                    key=lambda row, start=start, end=end: tuple(signatures[row, start:end]),
+                )
+            )
+
+        for query_id in (0, 17, 42):
+            query = signatures[query_id]
+            for limit in (1, 5, 20, 100):
+                expected = []
+                seen = set()
+                for prefix_length in range(forest._k, 0, -1):
+                    for tree, order in enumerate(tree_orders):
+                        start = tree * forest._k
+                        end = start + prefix_length
+                        for row in order:
+                            if np.array_equal(signatures[row, start:end], query[start:end]):
+                                if row not in seen:
+                                    expected.append(row)
+                                    seen.add(row)
+                                    if len(expected) == min(limit, len(signatures)):
+                                        break
+                        if len(expected) == min(limit, len(signatures)):
+                            break
+                    if len(expected) == min(limit, len(signatures)):
+                        break
+
+                np.testing.assert_array_equal(forest.query(query, limit), expected)
+
+    def test_query_requires_positive_k(self, indexed_forest, random_signatures):
+        with pytest.raises(ValueError, match="k must be positive"):
+            indexed_forest.query(random_signatures[0], k=0)
 
     def test_query_returns_candidates(self, indexed_forest, random_signatures):
         """Test that query returns candidate indices."""
@@ -403,6 +471,18 @@ class TestLSHForestStorage:
         with pytest.raises(ValueError, match="requires store=True"):
             lsh.get_knn_graph(k=5)
 
+    def test_store_false_still_builds_queryable_prefix_index(self):
+        signatures = np.array(
+            [[1, 2, 3, 4], [1, 2, 8, 9], [7, 6, 5, 4]],
+            dtype=np.uint64,
+        )
+        lsh = LSHForest(d=4, l=2, store=False)
+        lsh.batch_add(signatures)
+        lsh.index()
+
+        assert lsh.size == 3
+        assert lsh.query(signatures[0], k=2).tolist() == [0, 1]
+
 
 # =============================================================================
 # Persistence Tests
@@ -433,6 +513,34 @@ class TestLSHForestPersistence:
             result_orig = indexed_forest.query(random_signatures[0], k=5)
             result_loaded = loaded.query(random_signatures[0], k=5)
             np.testing.assert_array_equal(result_orig, result_loaded)
+
+    def test_load_rebuilds_legacy_exact_band_state(self, tmp_path):
+        signatures = np.array(
+            [[1, 2, 3, 4], [1, 2, 8, 9], [7, 6, 5, 4]],
+            dtype=np.uint64,
+        )
+        legacy_state = {
+            "d": 4,
+            "l": 2,
+            "k": 2,
+            "store": True,
+            "weighted": False,
+            "signatures": signatures,
+            "signatures_list": [],
+            "hash_bands": np.zeros((3, 2), dtype=np.uint64),
+            "sorted_hashes_flat": np.zeros(6, dtype=np.uint64),
+            "sorted_indices_flat": np.arange(6, dtype=np.int32),
+            "band_offsets": np.array([0, 3, 6], dtype=np.int64),
+            "n_indexed": 3,
+            "is_indexed": True,
+        }
+        path = tmp_path / "legacy-lsh.pkl"
+        with path.open("wb") as handle:
+            pickle.dump(legacy_state, handle)
+
+        loaded = LSHForest.load(str(path))
+
+        assert loaded.query(signatures[0], k=2).tolist() == [0, 1]
 
 
 # =============================================================================
@@ -487,6 +595,18 @@ class TestLSHForestWeighted:
         sig_b = np.ones((128, 2), dtype=np.uint64)
         dist = LSHForest.get_weighted_distance(sig_a, sig_b)
         assert dist == 1.0
+
+    def test_weighted_prefix_uses_both_signature_components(self):
+        signatures = np.empty((2, 4, 2), dtype=np.uint64)
+        signatures[0, :, 0] = 7
+        signatures[0, :, 1] = 1
+        signatures[1, :, 0] = 7
+        signatures[1, :, 1] = 99
+        forest = LSHForest(d=4, l=2, weighted=True)
+        forest.batch_add(signatures)
+        forest.index()
+
+        assert forest.query(signatures[0], k=2).tolist() == [0]
 
 
 # =============================================================================
@@ -641,6 +761,17 @@ class TestLSHForestIncrementalOperations:
 
         assert lsh.size == 0
         assert lsh.is_clean
+
+    def test_index_is_idempotent(self, random_signatures):
+        lsh = LSHForest(d=128, l=8)
+        lsh.batch_add(random_signatures)
+        lsh.index()
+        before = lsh.query(random_signatures[0], k=10)
+
+        lsh.index()
+
+        assert lsh.size == len(random_signatures)
+        np.testing.assert_array_equal(lsh.query(random_signatures[0], k=10), before)
 
     def test_query_empty_forest_returns_empty(self):
         """Querying empty forest should return empty results.


### PR DESCRIPTION
## Summary

- Replace exact-band lookup with adaptive lexicographic prefix search matching TMAP1 semantics.
- Fix weighted-prefix comparison, `store=False` queries, persistence migration, and repeated indexing.
- Parallelize tree construction and cap graph candidate memory.

## Benchmark

20k ChEMBL Morgan-2048 fingerprints, 100 queries, `k=20`, `kc=50`; identical TMAP2 MinHash signatures with exact Jaccard reranking.

| Profile (d/l) | Old Numba recall@20 | New recall@20 | C++ recall@20 | New query time / 100 | C++ query time / 100 |
|---|---:|---:|---:|---:|---:|
| 128/16 | 0.171 | 0.715 | 0.714 | 0.063 s | 0.100 s |
| 256/32 | 0.246 | 0.749 | 0.748 | 0.097 s | 0.139 s |
| 512/64 | 0.301 | 0.800 | 0.801 | 0.123 s | 0.233 s |

Candidate sets matched C++ for all 300 profile/query pairs. Warm query search was 1.43–1.89x faster than C++.

Tradeoff: adaptive lookup evaluates a real `k * kc` candidate budget, so it does more useful work than the old near-empty exact-band search.

## Checks

- `ruff check src/tmap tests`
- 226 focused LSH, MinHash, estimator, end-to-end, and layout tests passed